### PR TITLE
Search endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 DATABASE_URL=postgres://opentrials:password@localhost:5432/opentrials_api_development
 TEST_DATABASE_URL=postgres://opentrials:password@localhost:5432/opentrials_api_test
+ELASTICSEARCH_URL=http://localhost:9200
 PORT=10010
 HOST=localhost

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -1,0 +1,20 @@
+const client = require('../../config').elasticsearch;
+
+function search(req, res) {
+  const query = req.swagger.params.q.value;
+
+  return client.search({ q: query })
+    .then((esResult) => {
+      res.json({
+        total_count: esResult.hits.hits.length,
+        items: esResult.hits.hits.map((hit) => hit._source),
+      });
+    })
+    .catch((err) => {
+      res.finish();
+    });
+}
+
+module.exports = {
+  search: search,
+};

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -1,9 +1,15 @@
 const client = require('../../config').elasticsearch;
 
 function search(req, res) {
-  const query = req.swagger.params.q.value;
+  const page = req.swagger.params.page.value;
+  const perPage = 20;
+  const searchQuery = {
+    q: req.swagger.params.q.value,
+    from: (page - 1) * perPage,
+    size: perPage,
+  };
 
-  return client.search({ q: query })
+  return client.search(searchQuery)
     .then((esResult) => {
       res.json({
         total_count: esResult.hits.hits.length,

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -2,7 +2,7 @@ const client = require('../../config').elasticsearch;
 
 function search(req, res) {
   const page = req.swagger.params.page.value;
-  const perPage = 20;
+  const perPage = req.swagger.params.per_page.value;
   const searchQuery = {
     q: req.swagger.params.q.value,
     from: (page - 1) * perPage,
@@ -12,7 +12,7 @@ function search(req, res) {
   return client.search(searchQuery)
     .then((esResult) => {
       res.json({
-        total_count: esResult.hits.hits.length,
+        total_count: esResult.hits.total,
         items: esResult.hits.hits.map((hit) => hit._source),
       });
     })

--- a/api/controllers/trials.js
+++ b/api/controllers/trials.js
@@ -17,14 +17,6 @@ function getTrial(req, res) {
     });
 }
 
-function listTrials(req, res) {
-  return new Trial().fetchAll({ withRelated: ['locations', 'interventions'] })
-    .then((trials) => (
-      res.json(trials)
-    ));
-}
-
 module.exports = {
   get: getTrial,
-  list: listTrials,
 }

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -48,25 +48,6 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
 
-  /trials:
-    x-swagger-router-controller: trials
-    get:
-      tags:
-        - trials
-      description: Returns list of trials
-      # used as the method name of the controller
-      operationId: list
-      responses:
-        "200":
-          description: Success
-          schema:
-            # a pointer to a definition
-            $ref: "#/definitions/TrialsList"
-        # responses may fall through to errors
-        default:
-          description: Error
-          schema:
-            $ref: "#/definitions/ErrorResponse"
   /trials/{id}:
     x-swagger-router-controller: trials
     get:
@@ -127,10 +108,6 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/TrialPerson'
-  TrialsList:
-    type: array
-    items:
-      $ref: '#/definitions/Trial'
 
   TrialLocation:
     required:

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -25,6 +25,12 @@ paths:
           in: query
           description: The search query
           type: string
+        - name: page
+          in: query
+          description: The page number
+          type: integer
+          minimum: 1
+          default: 1
       responses:
         "200":
           description: Success

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -13,6 +13,28 @@ produces:
 paths:
   /swagger.yaml:
     x-swagger-pipe: swagger_raw
+  /search:
+    x-swagger-router-controller: search
+    get:
+      tags:
+        - search
+      description: Search stuff
+      operationId: search
+      parameters:
+        - name: q
+          in: query
+          description: The search query
+          type: string
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/SearchResults"
+        default:
+          description: Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+
   /trials:
     x-swagger-router-controller: trials
     get:
@@ -175,6 +197,18 @@ definitions:
         type: string
         enum:
           - other
+
+  SearchResults:
+    required:
+      - total_count
+      - items
+    properties:
+      total_count:
+        type: integer
+      items:
+        type: array
+        items:
+          $ref: '#/definitions/Trial'
 
   ErrorResponse:
     required:

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -18,7 +18,7 @@ paths:
     get:
       tags:
         - trials
-      description: Search stuff
+      description: Search trials
       operationId: search
       parameters:
         - name: q

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -17,7 +17,7 @@ paths:
     x-swagger-router-controller: search
     get:
       tags:
-        - search
+        - trials
       description: Search stuff
       operationId: search
       parameters:

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -31,6 +31,13 @@ paths:
           type: integer
           minimum: 1
           default: 1
+        - name: per_page
+          in: query
+          description: Number of items per page
+          type: integer
+          minimum: 10
+          maximum: 100
+          default: 20
       responses:
         "200":
           description: Success

--- a/config/index.js
+++ b/config/index.js
@@ -1,4 +1,5 @@
 require('dotenv').config();
+const elasticsearch = require('elasticsearch');
 const path = require('path');
 const config = {
   host: process.env.HOST || 'localhost',
@@ -19,6 +20,10 @@ const config = {
       },
     }],
   },
+
+  elasticsearch: new elasticsearch.Client({
+    host: process.env.ELASTICSEARCH_URL,
+  }),
 };
 
 const env = process.env.NODE_ENV || 'development';

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "precoveralls": "npm run coverage",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "migrate": "knex migrate:latest",
-    "start": "nodemon server.js"
+    "start": "nodemon server.js",
+    "reindex": "node --use_strict ./tools/create-trials-index.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "bookshelf": "^0.9.2",
     "dotenv": "^2.0.0",
+    "elasticsearch": "^9.0.2",
     "good": "^6.6.0",
     "good-console": "^5.3.1",
     "hapi": "^13.0.0",
@@ -40,6 +41,7 @@
     "mocha": "^2.4.5",
     "nodemon": "^1.8.1",
     "should": "^8.2.2",
+    "sinon": "^1.17.3",
     "sqlite3": "^3.1.1",
     "supertest": "^1.0.0"
   },

--- a/server.js
+++ b/server.js
@@ -15,7 +15,6 @@ SwaggerHapi.create(config.swaggerHapi, (err, swaggerHapi) => {
   });
   server.address = () => ({ port });
 
-
   server.register(plugins, (_err) => {
     if (_err) { throw _err; }
     server.start(() => {

--- a/test/api/controllers/search.js
+++ b/test/api/controllers/search.js
@@ -1,0 +1,87 @@
+const sinon = require('sinon');
+const elasticsearch = require('../../../config').elasticsearch;
+
+describe('Search', () => {
+  before(clearDB)
+
+  afterEach(clearDB)
+
+  describe('GET /v1/search', () => {
+    let searchStub;
+
+    beforeEach(() => {
+      searchStub = sinon.stub(elasticsearch, 'search')
+    });
+
+    afterEach(() => {
+      searchStub.restore();
+    });
+
+    it('returns empty list if no trials were found', () => {
+      const esResult = {
+        hits: {
+          hits: [],
+        },
+      };
+
+      searchStub.returns(Promise.resolve(esResult));
+
+      return server.inject('/v1/search')
+        .then((response) => {
+          response.statusCode.should.equal(200);
+          JSON.parse(response.result).should.deepEqual({
+            total_count: 0,
+            items: [],
+          });
+        })
+    });
+
+    it('returns the trials', () => {
+      const trial = fixtures.trial();
+      trial.attributes.id = 'd429efb2-dbf1-11e5-b5d2-0a1d41d68578';
+      const esResult = {
+        hits: {
+          hits: [
+            { _source: trial.toJSON() },
+          ],
+        },
+      };
+
+      searchStub.returns(Promise.resolve(esResult));
+
+      return server.inject('/v1/search')
+        .then((response) => {
+          const items = esResult.hits.hits.map((hit) => {
+            hit._source.registration_date = hit._source.registration_date.toISOString();
+            return hit._source;
+          });
+
+          response.statusCode.should.equal(200);
+          JSON.parse(response.result).should.deepEqual({
+            total_count: items.length,
+            items: items,
+          });
+        })
+    });
+
+    it('passes the query string to elasticsearch', () => {
+      searchStub.returns(Promise.reject(new Error('ElasticSearch error')));
+
+      return server.inject('/v1/search?q=foo')
+        .then(() => {
+          searchStub.calledWithMatch({ q: 'foo' }).should.be.true();
+        });
+    });
+
+    it.skip('returns 500 if there were some error with elasticsearch', () => {
+      // FIXME: There doesn't seems to be a way to set the status code with the
+      // current swagger-node-runner version. This was fixed in later versions,
+      // but other problems were created, so we can't update yet.
+      // See https://github.com/theganyo/swagger-node-runner/issues/33
+      searchStub.returns(Promise.reject(new Error('ElasticSearch error')));
+
+      return server.inject('/v1/search')
+        .then((response) => response.statusCode.should.equal(500));
+    });
+  });
+});

--- a/test/api/controllers/trials.js
+++ b/test/api/controllers/trials.js
@@ -6,32 +6,6 @@ describe('Trials', () => {
 
   afterEach(clearDB)
 
-  describe('GET /v1/trials', () => {
-    it('returns empty list if there\'re no trials', () => (
-      server.inject('/v1/trials')
-        .then((response) => {
-          response.statusCode.should.equal(200);
-          JSON.parse(response.result).should.deepEqual([]);
-        })
-    ));
-
-    it('returns the list of trials', () => {
-      return fixtures.trialWithRelated()
-        .then((model) =>
-          server.inject('/v1/trials')
-            .then((response) => {
-              response.statusCode.should.equal(200);
-
-              const result = JSON.parse(response.result);
-              const expectedResult = model.toJSON();
-              expectedResult.registration_date = expectedResult.registration_date.toISOString()
-
-              result.should.deepEqual([expectedResult]);
-            })
-        );
-    });
-  });
-
   describe('GET /v1/trials/{id}', () => {
     it('returns 404 if there\'s no trial with the received ID', () => (
       server.inject('/v1/trials/foo')

--- a/tools/create-trials-index.js
+++ b/tools/create-trials-index.js
@@ -25,7 +25,7 @@ new Trial().fetchAll({ withRelated: relatedModels })
       body: bulkBody,
     });
   }).then((resp) => {
-    console.info(resp.items.length + ' trials successfully reindexed into ElasticSearch.');
+    console.info(`${resp.items.length} trials successfully reindexed into ElasticSearch.`);
     process.exit();
   }).catch((err) => {
     throw err;

--- a/tools/create-trials-index.js
+++ b/tools/create-trials-index.js
@@ -8,7 +8,8 @@ const relatedModels = [
   'interventions',
 ];
 
-new Trial().fetchAll({ withRelated: relatedModels })
+client.indices.create({ index: 'trials' })
+  .then(() => new Trial().fetchAll({ withRelated: relatedModels }))
   .then((trials) => {
     const bulkBody = trials.models.reduce((result, trial) => {
       const action = {

--- a/tools/create-trials-index.js
+++ b/tools/create-trials-index.js
@@ -1,0 +1,32 @@
+/* eslint-disable no-console */
+
+const client = require('../config').elasticsearch;
+const Trial = require('../api/models/trial');
+
+const relatedModels = [
+  'locations',
+  'interventions',
+];
+
+new Trial().fetchAll({ withRelated: relatedModels })
+  .then((trials) => {
+    const bulkBody = trials.models.reduce((result, trial) => {
+      const action = {
+        index: {
+          _index: 'trials',
+          _type: 'trial',
+          _id: trial.id,
+        },
+      };
+      return result.concat([action, trial.toJSON()]);
+    }, []);
+
+    return client.bulk({
+      body: bulkBody,
+    });
+  }).then((resp) => {
+    console.info(resp.items.length + ' trials successfully reindexed into ElasticSearch.');
+    process.exit();
+  }).catch((err) => {
+    throw err;
+  });


### PR DESCRIPTION
This adds the http://opentrials-api.herokuapp.com/v1/search endpoint. This endpoint allows searching on all fields of a trial (including its related entities). For example, http://opentrials-api.herokuapp.com/v1/search?q=united%20states

It also accepts a `per_page` attribute (between 10 and 100), and a `page`.

To create the elasticsearch index, you have to run `npm run reindex`.

The ElasticSearch queries don't do partial matches by default (i.e. `musc` won't match `muscle`), but you can use ES' query language, like `mus*` or `muscle OR heart`, etc.

This PR also removes the `/v1/trials` endpoint. The data it returned can be returned by simply calling `/v1/search` without a query, so it's redundant.