### PR TITLE
Search filters

### DIFF
--- a/api/controllers/locations.js
+++ b/api/controllers/locations.js
@@ -1,0 +1,13 @@
+const Location = require('../models/location');
+
+function list(req, res) {
+  return new Location().fetchAll()
+    .catch((err) => {
+      // FIXME: We're ignoring errors for now, but we should at least log them.
+    })
+    .then(res.json);
+}
+
+module.exports = {
+  list,
+}

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -4,6 +4,7 @@ function search(req, res) {
   const page = req.swagger.params.page.value;
   const perPage = req.swagger.params.per_page.value;
   const searchQuery = {
+    index: 'trials',
     q: req.swagger.params.q.value,
     from: (page - 1) * perPage,
     size: perPage,

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -53,7 +53,7 @@ paths:
     get:
       tags:
         - trials
-      description: Returns list of trials
+      description: Returns trial details
       # used as the method name of the controller
       operationId: get
       parameters:
@@ -75,6 +75,24 @@ paths:
           description: Error
           schema:
             $ref: "#/definitions/ErrorResponse"
+
+  /locations:
+    x-swagger-router-controller: locations
+    get:
+      tags:
+        - locations
+      description: Returns list of locations
+      operationId: list
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/LocationList"
+        default:
+          description: Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+
 # complex objects have schema definitions
 definitions:
   Trial:
@@ -199,6 +217,11 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Trial'
+
+  LocationList:
+    type: array
+    items:
+      $ref: '#/definitions/Location'
 
   ErrorResponse:
     required:

--- a/test/api/controllers/locations.js
+++ b/test/api/controllers/locations.js
@@ -1,0 +1,26 @@
+const locationsController = require('../../../api/controllers/locations');
+const Location = require('../../../api/models/location');
+
+describe('Locations', () => {
+  before(clearDB)
+
+  afterEach(clearDB)
+
+  describe('GET /v1/locations', () => {
+    it('returns the list of locations', () => (
+      fixtures.location().save()
+        .then((model) => (
+          server.inject('/v1/locations/')
+            .then((response) => {
+              response.statusCode.should.equal(200);
+
+              const result = JSON.parse(response.result);
+              const expectedResult = [model.toJSON()];
+
+              result.should.deepEqual(expectedResult);
+            })
+        ))
+    ));
+  });
+});
+

--- a/tools/create-trials-index.js
+++ b/tools/create-trials-index.js
@@ -7,8 +7,76 @@ const relatedModels = [
   'locations',
   'interventions',
 ];
+const trialsIndex = {
+  index: 'trials',
+  body: {
+    mappings: {
+      trial: {
+        properties: {
+          brief_summary: {
+            type: 'string',
+          },
+          id: {
+            type: 'string',
+            index: 'not_analyzed',
+          },
+          interventions: {
+            properties: {
+              attributes: {
+                properties: {
+                  id: {
+                    type: 'string',
+                    index: 'not_analyzed',
+                  },
+                  name: {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          },
+          locations: {
+            properties: {
+              attributes: {
+                properties: {
+                  id: {
+                    type: 'string',
+                    index: 'not_analyzed',
+                  },
+                  name: {
+                    type: 'string',
+                    copy_to: 'location',
+                  },
+                  type: {
+                    type: 'string',
+                    index: 'not_analyzed',
+                  },
+                },
+              },
+              role: {
+                type: 'string',
+                index: 'not_analyzed',
+              },
+            },
+          },
+          location: {
+            type: 'string',
+          },
+          public_title: {
+            type: 'string',
+          },
+          registration_date: {
+            type: 'date',
+            format: 'strict_date_optional_time||epoch_millis',
+          },
+        },
+      },
+    },
+  },
+};
 
-client.indices.create({ index: 'trials' })
+client.indices.delete({ index: 'trials' })
+  .then(() => client.indices.create(trialsIndex))
   .then(() => new Trial().fetchAll({ withRelated: relatedModels }))
   .then((trials) => {
     const bulkBody = trials.models.reduce((result, trial) => {


### PR DESCRIPTION
_Related to https://github.com/opentrials/opentrials/pull/33. Fixes #13._

There were only two things needed here: add a `/locations` endpoint, so the opentrials.net site could show a list of locations to filter by, and explicitly generating a mapping in elasticsearch.

The mapping was needed because we're using filters as part of the query string. For example, to query the results in a specific location (say Brazil), the user could simply pass `location:Brazil` (http://opentrials-api.herokuapp.com/v1/search?q=location:Brazil). This was inspired by GitHub's search qualifiers (check https://developer.github.com/v3/search/#search-issues), although it doesn't work the same way yet. For example, the default operator is `OR`, which means that a query for `osteoporosis location:Brazil` will returns trials that contain `osteoporosis` or are located in `Brazil`. We can change this afterwards, though.