### PR TITLE
[#11] Enable CORS

### DIFF
--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -13,6 +13,7 @@ produces:
 paths:
   /swagger.yaml:
     x-swagger-pipe: swagger_raw
+
   /search:
     x-swagger-router-controller: search
     get:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -32,6 +32,7 @@ swagger:
 
     # pipe to serve swagger (endpoint is in swagger.yaml)
     swagger_raw:
-      name: swagger_raw
+      - cors
+      - swagger_raw
 
 # any other values in this file are just loaded into the config for application access...

--- a/server.js
+++ b/server.js
@@ -12,6 +12,9 @@ SwaggerHapi.create(config.swaggerHapi, (err, swaggerHapi) => {
   server.connection({
     host: config.host,
     port,
+    routes: {
+      cors: true,
+    },
   });
   server.address = () => ({ port });
 

--- a/test/integration/server.js
+++ b/test/integration/server.js
@@ -1,0 +1,12 @@
+describe('server', () => {
+  it('has CORS enabled', () => (
+    server.inject({
+      url: '/v1/swagger.yaml',
+      headers: {
+        Origin: 'http://foo.com',
+      }
+    }).then((response) => {
+      response.headers.should.containEql({ 'access-control-allow-origin': '*' });
+    })
+  ));
+});


### PR DESCRIPTION
To test it you can use:

> curl -s -H "Origin: http://foo.com" -v http://opentrials-api.herokuapp.com/v1/swagger.yaml > /dev/null

You should see `Access-Control-Allow-Origin: *` in the response's headers.

You can also use http://petstore.swagger.io/ adding `http://opentrials-api.herokuapp.com/v1/swagger.yaml` into the text input in the header and clicking on "Explore".

Fixes #11