### PR TITLE
[#27] Downgrade ElasticSearch to 1.5.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,5 +16,5 @@ db:
   restart: always
 
 elasticsearch:
-  image: elasticsearch:2.2
+  image: elasticsearch:1.5.2
   restart: always

--- a/tools/create-trials-index.js
+++ b/tools/create-trials-index.js
@@ -136,7 +136,7 @@ const trialsIndex = {
           },
           registration_date: {
             type: 'date',
-            format: 'strict_date_optional_time||epoch_millis',
+            format: 'dateOptionalTime',
           },
         },
       },


### PR DESCRIPTION
That's the latest version supported on AWS