### PR TITLE
[#65] Return at most 100 pages

### DIFF
--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -31,6 +31,7 @@ paths:
           description: The page number
           type: integer
           minimum: 1
+          maximum: 100
           default: 1
         - name: per_page
           in: query

--- a/test/api/controllers/search.js
+++ b/test/api/controllers/search.js
@@ -147,6 +147,18 @@ describe('Search', () => {
           });
       });
 
+      it('validates that page is smaller than 100', () => {
+        // FIXME: Should return error HTTP status code
+        return server.inject('/v1/search?page=101')
+          .then((response) => {
+            const result = JSON.parse(response.result);
+
+            should(result.failedValidation).be.true();
+            should(result.code).equal('MAXIMUM');
+            should(result.paramName).equal('page');
+          });
+      });
+
       it('validates that items per page is greater than 10', () => {
         // FIXME: Should return error HTTP status code
         return server.inject('/v1/search?per_page=9')


### PR DESCRIPTION
There're performance issues on paginating too many results. GitHub limits
1,000 results per query, for example. I would like to do the same, but that
would require validating on two query parameters (`page` and `per_page`). It's
easier to simply limit on a single parameter, so that's what I've done here. If
we have performance issues, we can improve on this solution.

In the worst case, a user would be able to get 100 pages with 100 results each,
totaling 10,000 results.

Fixes opentrials/opentrials#65

Related to https://github.com/opentrials/opentrials/commit/593b0776a2b7b8702cf35d887fd2e703333f279a