### PR TITLE
Add urls to entities

### DIFF
--- a/api/models/condition.js
+++ b/api/models/condition.js
@@ -4,6 +4,7 @@ require('./trial');
 
 const bookshelf = require('../../config').bookshelf;
 const BaseModel = require('./base');
+const helpers = require('../helpers');
 
 const Condition = BaseModel.extend({
   tableName: 'conditions',
@@ -13,6 +14,11 @@ const Condition = BaseModel.extend({
   ],
   trials: function () {
     return this.belongsToMany('Trial', 'trials_conditions');
+  },
+  virtuals: {
+    url: function () {
+      return helpers.urlFor(this);
+    },
   },
 });
 

--- a/api/models/intervention.js
+++ b/api/models/intervention.js
@@ -4,6 +4,7 @@ require('./trial');
 
 const bookshelf = require('../../config').bookshelf;
 const BaseModel = require('./base');
+const helpers = require('../helpers');
 
 const Intervention = BaseModel.extend({
   tableName: 'interventions',
@@ -14,6 +15,11 @@ const Intervention = BaseModel.extend({
   ],
   trials: function () {
     return this.belongsToMany('Trial', 'trials_interventions');
+  },
+  virtuals: {
+    url: function () {
+      return helpers.urlFor(this);
+    },
   },
 });
 

--- a/api/models/location.js
+++ b/api/models/location.js
@@ -4,6 +4,7 @@ require('./trial');
 
 const bookshelf = require('../../config').bookshelf;
 const BaseModel = require('./base');
+const helpers = require('../helpers');
 
 const Location = BaseModel.extend({
   tableName: 'locations',
@@ -15,6 +16,11 @@ const Location = BaseModel.extend({
   trials: function () {
     return this.belongsToMany('Trial', 'trials_locations',
       'location_id', 'trial_id').withPivot(['role']);
+  },
+  virtuals: {
+    url: function () {
+      return helpers.urlFor(this);
+    },
   },
   topLocations: function () {
     return bookshelf.knex

--- a/api/models/organisation.js
+++ b/api/models/organisation.js
@@ -4,6 +4,7 @@ require('./trial');
 
 const bookshelf = require('../../config').bookshelf;
 const BaseModel = require('./base');
+const helpers = require('../helpers');
 
 const Organisation = BaseModel.extend({
   tableName: 'organisations',
@@ -14,6 +15,11 @@ const Organisation = BaseModel.extend({
   trials: function () {
     return this.belongsToMany('Trial', 'trials_organisations',
       'organisation_id', 'trial_id').withPivot(['role']);
+  },
+  virtuals: {
+    url: function () {
+      return helpers.urlFor(this);
+    },
   },
 });
 

--- a/api/models/person.js
+++ b/api/models/person.js
@@ -4,6 +4,7 @@ require('./trial');
 
 const bookshelf = require('../../config').bookshelf;
 const BaseModel = require('./base');
+const helpers = require('../helpers');
 
 const Person = BaseModel.extend({
   tableName: 'persons',
@@ -14,6 +15,11 @@ const Person = BaseModel.extend({
   trials: function () {
     return this.belongsToMany('Trial', 'trials_persons',
       'person_id', 'trial_id').withPivot(['role']);
+  },
+  virtuals: {
+    url: function () {
+      return helpers.urlFor(this);
+    },
   },
 });
 

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -408,10 +408,13 @@ definitions:
     required:
       - id
       - name
+      - url
     properties:
       id:
         type: string
       name:
+        type: string
+      url:
         type: string
       type:
         type: string
@@ -424,10 +427,13 @@ definitions:
     required:
       - id
       - name
+      - url
     properties:
       id:
         type: string
       name:
+        type: string
+      url:
         type: string
       type:
         type: string
@@ -439,10 +445,13 @@ definitions:
     required:
       - id
       - name
+      - url
     properties:
       id:
         type: string
       name:
+        type: string
+      url:
         type: string
 
   TrialPerson:
@@ -461,10 +470,13 @@ definitions:
     required:
       - id
       - name
+      - url
     properties:
       id:
         type: string
       name:
+        type: string
+      url:
         type: string
       type:
         type: string
@@ -487,10 +499,13 @@ definitions:
     required:
       - id
       - name
+      - url
     properties:
       id:
         type: string
       name:
+        type: string
+      url:
         type: string
 
   Record:

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -456,7 +456,7 @@ definitions:
 
   TrialPerson:
     allOf:
-      - $ref: '#/definitions/Location'
+      - $ref: '#/definitions/Person'
       - type: object
         properties:
           role:
@@ -485,7 +485,7 @@ definitions:
 
   TrialOrganisation:
     allOf:
-      - $ref: '#/definitions/Location'
+      - $ref: '#/definitions/Organisation'
       - type: object
         properties:
           role:

--- a/test/api/models/condition.js
+++ b/test/api/models/condition.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const should = require('should');
+const helpers = require('../../../api/helpers');
 const Condition = require('../../../api/models/condition');
 
 describe('Condition', () => {
@@ -24,4 +25,10 @@ describe('Condition', () => {
     })
   });
 
+  describe('url', () => {
+    it('returns the url', () => {
+      return factory.build('condition')
+        .then((condition) => should(condition.toJSON().url).eql(helpers.urlFor(condition)));
+    });
+  });
 });

--- a/test/api/models/intervention.js
+++ b/test/api/models/intervention.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const should = require('should');
+const helpers = require('../../../api/helpers');
 const Intervention = require('../../../api/models/intervention');
 
 describe('Intervention', () => {
@@ -22,5 +23,12 @@ describe('Intervention', () => {
           should(trialsIds).containEql(trialId);
         })
     })
+  });
+
+  describe('url', () => {
+    it('returns the url', () => {
+      return factory.build('intervention')
+        .then((intervention) => should(intervention.toJSON().url).eql(helpers.urlFor(intervention)));
+    });
   });
 });

--- a/test/api/models/location.js
+++ b/test/api/models/location.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const should = require('should');
+const helpers = require('../../../api/helpers');
 const Location = require('../../../api/models/location');
 
 describe('Location', () => {
@@ -37,6 +38,13 @@ describe('Location', () => {
         .then((result) => {
           should(result.length).equal(10);
         });
+    });
+  });
+
+  describe('url', () => {
+    it('returns the url', () => {
+      return factory.build('location')
+        .then((loc) => should(loc.toJSON().url).eql(helpers.urlFor(loc)));
     });
   });
 });

--- a/test/api/models/organisation.js
+++ b/test/api/models/organisation.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const should = require('should');
+const helpers = require('../../../api/helpers');
 const Organisation = require('../../../api/models/organisation');
 
 describe('Organisation', () => {
@@ -24,4 +25,10 @@ describe('Organisation', () => {
     })
   });
 
+  describe('url', () => {
+    it('returns the url', () => {
+      return factory.build('person')
+        .then((person) => should(person.toJSON().url).eql(helpers.urlFor(person)));
+    });
+  });
 });

--- a/test/api/models/person.js
+++ b/test/api/models/person.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const should = require('should');
+const helpers = require('../../../api/helpers');
 const Person = require('../../../api/models/person');
 
 describe('Person', () => {
@@ -24,4 +25,10 @@ describe('Person', () => {
     })
   });
 
+  describe('url', () => {
+    it('returns the url', () => {
+      return factory.build('person')
+        .then((person) => should(person.toJSON().url).eql(helpers.urlFor(person)));
+    });
+  });
 });

--- a/tools/create-trials-index.js
+++ b/tools/create-trials-index.js
@@ -32,6 +32,10 @@ const trialMapping = {
           type: 'string',
           copy_to: 'intervention',
         },
+        url: {
+          type: 'string',
+          index: 'not_analyzed',
+        },
       },
     },
     intervention: {
@@ -46,6 +50,10 @@ const trialMapping = {
         name: {
           type: 'string',
           copy_to: 'location',
+        },
+        url: {
+          type: 'string',
+          index: 'not_analyzed',
         },
         type: {
           type: 'string',
@@ -70,6 +78,10 @@ const trialMapping = {
           type: 'string',
           copy_to: 'condition',
         },
+        url: {
+          type: 'string',
+          index: 'not_analyzed',
+        },
       },
     },
     condition: {
@@ -85,10 +97,14 @@ const trialMapping = {
           type: 'string',
           copy_to: 'person',
         },
-      },
-      role: {
-        type: 'string',
-        index: 'not_analyzed',
+        url: {
+          type: 'string',
+          index: 'not_analyzed',
+        },
+        role: {
+          type: 'string',
+          index: 'not_analyzed',
+        },
       },
     },
     person: {
@@ -104,10 +120,14 @@ const trialMapping = {
           type: 'string',
           copy_to: 'organisation',
         },
-      },
-      role: {
-        type: 'string',
-        index: 'not_analyzed',
+        url: {
+          type: 'string',
+          index: 'not_analyzed',
+        },
+        role: {
+          type: 'string',
+          index: 'not_analyzed',
+        },
       },
     },
     organisation: {


### PR DESCRIPTION
Every entity now has an `url` attribute which points to their API endpoint. This is needed for https://github.com/opentrials/opentrials/issues/124.

@roll This is blocking @smth, so I'm merging it. Please take a look when you can :+1: