### PR TITLE
fixed records unique constraint

### DIFF
--- a/migrations/20160527115742_fix_records_unique_constraint.js
+++ b/migrations/20160527115742_fix_records_unique_constraint.js
@@ -1,0 +1,14 @@
+'use strict';
+
+exports.up = (knex) => (
+  knex.schema
+    .table('records', (table) => {
+      table.dropUnique(undefined, 'trialrecords_primary_register_primary_id_unique');
+      table.unique(['source_id', 'primary_id']);
+    })
+);
+
+exports.down = () => {
+  // Rollback will fail on a good data
+  throw Error('Destructive migration can\'t be rolled back.');
+};


### PR DESCRIPTION
Current constraint is wrong because for example `source_id=ictrp` having records from other primary registries (so database re-population was in write errors).