### PR TITLE
Fix bug where the API spec required some fields that could be null

### DIFF
--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -385,8 +385,6 @@ definitions:
       - id
       - url
       - public_title
-      - brief_summary
-      - registration_date
       - has_discrepancies
       - locations
       - interventions


### PR DESCRIPTION
This was introduced by a58871267e3db61df8ea6e1dd83d1bc688325fbc