### PR TITLE
[#194] Add trial.discrepancies and remove trial.has_discrepancies

### DIFF
--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -385,7 +385,6 @@ definitions:
       - id
       - url
       - public_title
-      - has_discrepancies
       - locations
       - interventions
       - persons
@@ -417,9 +416,6 @@ definitions:
           - female
       has_published_results:
         type: boolean
-      has_discrepancies:
-        type: boolean
-        description: Describes if there are any data discrepancies among the sources of this Trial.
       registration_date:
         type: string
         format: date-time
@@ -459,6 +455,10 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/PublicationSummary'
+      discrepancies:
+        type: object
+        items:
+          $ref: '#/definitions/Discrepancies'
 
   TrialLocation:
     allOf:
@@ -470,6 +470,7 @@ definitions:
             enum:
               - recruitment_countries
               - other
+
   Location:
     required:
       - id
@@ -695,6 +696,65 @@ definitions:
         type: string
       source:
         $ref: '#/definitions/Source'
+
+  Discrepancies:
+    description: Object listing the Trial's discrepant fields
+    properties:
+      public_title:
+        type: array
+        items:
+          $ref: '#/definitions/DiscrepantFieldString'
+      brief_summary:
+        type: array
+        items:
+          $ref: '#/definitions/DiscrepantFieldString'
+      gender:
+        type: array
+        items:
+          $ref: '#/definitions/DiscrepantFieldString'
+      target_sample_size:
+        type: array
+        items:
+          $ref: '#/definitions/DiscrepantFieldInteger'
+      registration_date:
+        type: array
+        items:
+          $ref: '#/definitions/DiscrepantFieldDateTime'
+
+  DiscrepantFieldString:
+    allOf:
+      - $ref: '#/definitions/DiscrepancyFieldBase'
+      - type: object
+        properties:
+          value:
+            type: string
+
+  DiscrepantFieldInteger:
+    allOf:
+      - $ref: '#/definitions/DiscrepancyFieldBase'
+      - type: object
+        properties:
+          value:
+            type: integer
+
+  DiscrepantFieldDateTime:
+    allOf:
+      - $ref: '#/definitions/DiscrepancyFieldBase'
+      - type: object
+        properties:
+          value:
+            type: string
+            format: date-time
+
+  DiscrepancyFieldBase:
+    required:
+      - record_id
+      - source_name
+    properties:
+      record_id:
+        type: string
+      source_name:
+        type: string
 
   Source:
     required:

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "node": "5.8.0"
   },
   "dependencies": {
-    "bookshelf": "^0.9.5",
     "bluebird": "^3.3.5",
+    "bookshelf": "^0.9.5",
     "dotenv": "^2.0.0",
     "elasticsearch": "^11.0.1",
     "good": "^7.0.0",
@@ -30,6 +30,7 @@
     "hapi": "^13.0.0",
     "http-aws-es": "^1.1.3",
     "knex": "^0.11.3",
+    "lodash": "^4.13.1",
     "node-uuid": "^1.4.7",
     "pg": "^4.4.4",
     "swagger-hapi": "^0.1.0"

--- a/tools/create-trials-index.js
+++ b/tools/create-trials-index.js
@@ -9,6 +9,30 @@ const Location = require('../api/models/location');
 const Person = require('../api/models/person');
 const Organisation = require('../api/models/organisation');
 
+
+function getDiscrepancyRecordMapping(valueMapping) {
+  return {
+    properties: {
+      field: {
+        enabled: 'false',
+      },
+      records: {
+        properties: {
+          record_id: {
+            type: 'string',
+            index: 'not_analyzed',
+          },
+          source_name: {
+            type: 'string',
+            index: 'not_analyzed',
+          },
+          value: valueMapping,
+        },
+      },
+    },
+  };
+}
+
 const trialMapping = {
   dynamic_templates: [
     {
@@ -167,6 +191,27 @@ const trialMapping = {
     publication: {
       type: 'string',
     },
+    discrepancies: {
+      properties: {
+        public_title: getDiscrepancyRecordMapping({
+          type: 'string',
+        }),
+        brief_summary: getDiscrepancyRecordMapping({
+          type: 'string',
+        }),
+        gender: getDiscrepancyRecordMapping({
+          type: 'string',
+          index: 'not_analyzed',
+        }),
+        target_sample_size: getDiscrepancyRecordMapping({
+          type: 'integer',
+        }),
+        registration_date: getDiscrepancyRecordMapping({
+          type: 'date',
+          format: 'dateOptionalTime',
+        }),
+      },
+    },
     public_title: {
       type: 'string',
     },
@@ -176,9 +221,6 @@ const trialMapping = {
     gender: {
       type: 'string',
       index: 'not_analyzed',
-    },
-    has_discrepancies: {
-      type: 'boolean',
     },
     has_published_results: {
       type: 'boolean',


### PR DESCRIPTION
If we don't calculate the discrepancies in the API, we'll have to do it in
the Explorer, which causes duplication because the code to check if a trial has
discrepancies is quite similar to the one to generate the discrepancies list.

opentrials/opentrials#194