### PR TITLE
Add API docs in /v1/docs endpoint

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -10,6 +10,7 @@ if (!process.env.ELASTICSEARCH_URL) {
 const elasticsearch = require('elasticsearch');
 const path = require('path');
 const good = require('good');
+const inert = require('inert');
 const httpAwsEs = require('http-aws-es');
 
 const config = {
@@ -34,6 +35,8 @@ const config = {
           }, 'stdout'],
         },
       },
+    }, {
+      register: inert,
     }],
   },
 };

--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
     "good-console": "^6.1.1",
     "hapi": "^13.0.0",
     "http-aws-es": "^1.1.3",
+    "inert": "^4.0.0",
     "knex": "^0.11.3",
     "lodash": "^4.13.1",
     "node-uuid": "^1.4.7",
     "pg": "^4.4.4",
-    "swagger-hapi": "^0.1.0"
+    "swagger-hapi": "^0.1.0",
+    "swagger-ui": "^2.1.4"
   },
   "main": "server.js",
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -1,32 +1,67 @@
 'use strict';
 
 const config = require('./config');
+const fs = require('fs');
+const path = require('path');
 const SwaggerHapi = require('swagger-hapi');
 const Hapi = require('hapi');
-const server = new Hapi.Server();
 
-SwaggerHapi.create(config.swaggerHapi, (err, swaggerHapi) => {
-  if (err) { throw err; }
+function setupSwaggerUi(server) {
+  const swaggerUiPath = path.join(__dirname, './node_modules/swagger-ui/dist');
+  const indexPath = path.join(swaggerUiPath, 'index.html');
 
-  const port = config.port;
-  const plugins = [swaggerHapi.plugin,
-                   ...config.hapi.plugins];
+  // Configure the Swagger file URL
+  const swaggerUiIndex = fs.readFileSync(indexPath, 'utf8');
+  const contents = swaggerUiIndex.replace(/url = ".+";/,
+                                          `url = "${config.url}/v1/swagger.yaml";`);
+  fs.writeFileSync(indexPath, contents, 'utf8');
 
-  server.connection({
-    host: config.host,
-    port,
-    routes: {
-      cors: true,
+  server.route({
+    method: 'GET',
+    path: '/v1/docs/{param*}',
+    handler: {
+      directory: {
+        path: swaggerUiPath,
+      },
+    },
+    config: {
+      cache: {
+        expiresIn: 7 * 24 * 60 * 60 * 1000,
+      },
     },
   });
-  server.address = () => ({ port });
+}
 
-  server.register(plugins, (_err) => {
-    if (_err) { throw _err; }
-    server.start(() => {
-      console.info('Server started at', server.info.uri); // eslint-disable-line no-console
+function startServer() {
+  const server = new Hapi.Server();
+
+  SwaggerHapi.create(config.swaggerHapi, (err, swaggerHapi) => {
+    if (err) { throw err; }
+
+    const port = config.port;
+    const plugins = [swaggerHapi.plugin,
+                     ...config.hapi.plugins];
+
+    server.connection({
+      host: config.host,
+      port,
+      routes: {
+        cors: true,
+      },
+    });
+    server.address = () => ({ port });
+
+    server.register(plugins, (_err) => {
+      if (_err) { throw _err; }
+
+      setupSwaggerUi(server);
+      server.start(() => {
+        console.info('Server started at', server.info.uri); // eslint-disable-line no-console
+      });
     });
   });
-});
 
-module.exports = server; // for testing
+  return server;
+}
+
+module.exports = startServer(); // for testing


### PR DESCRIPTION
This is generated using Swagger UI. Unfortunately, there's no way to configure
the swagger file's path in Swagger UI, so we need to directly change it in the
code. To avoid doing this change manually, I've added a small bit of code that
does it when starting the server. It's ugly and hacky, but it works for now.