### PR TITLE
[#254] Returns documents and change relationship between it and trials

### DIFF
--- a/api/models/document.js
+++ b/api/models/document.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const bookshelf = require('../../config').bookshelf;
+const BaseModel = require('./base');
+
+const Document = BaseModel.extend({
+  tableName: 'documents',
+  visible: [
+    'type',
+    'name',
+    'url',
+  ],
+});
+
+module.exports = bookshelf.model('Document', Document);

--- a/api/models/trial.js
+++ b/api/models/trial.js
@@ -6,6 +6,7 @@ require('./condition');
 require('./person');
 require('./organisation');
 require('./source');
+require('./document');
 require('./record');
 require('./publication');
 
@@ -23,6 +24,7 @@ const relatedModels = [
   'records.source',
   'publications',
   'publications.source',
+  'documents',
 ];
 
 const Trial = BaseModel.extend({
@@ -95,6 +97,9 @@ const Trial = BaseModel.extend({
   publications: function () {
     return this.belongsToMany('Publication', 'trials_publications',
       'trial_id', 'publication_id');
+  },
+  documents: function () {
+    return this.hasMany('Document');
   },
   records: function () {
     return this.hasMany('Record');

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -459,6 +459,10 @@ definitions:
         type: object
         items:
           $ref: '#/definitions/Discrepancies'
+      documents:
+        type: array
+        items:
+          $ref: '#/definitions/Document'
 
   TrialLocation:
     allOf:
@@ -754,6 +758,26 @@ definitions:
       record_id:
         type: string
       source_name:
+        type: string
+
+  Document:
+    required:
+      - name
+      - type
+      - url
+    properties:
+      name:
+        type: string
+      type:
+        type: string
+        enum:
+          - csr
+          - epar_segment
+          - blank_consent_form
+          - patient_information_sheet
+          - blank_case_report_form
+          - other
+      url:
         type: string
 
   Source:

--- a/migrations/20160708115615_remove_trials_documents_and_documents_slug_and_add_trial_id_type_and_url_to_documents.js
+++ b/migrations/20160708115615_remove_trials_documents_and_documents_slug_and_add_trial_id_type_and_url_to_documents.js
@@ -1,0 +1,30 @@
+'use strict';
+
+exports.up = (knex) => (
+  knex.schema
+    .dropTable('trials_documents')
+    .table('documents', (table) => {
+      table.dropColumns([
+        'slug',
+      ]);
+      table.uuid('trial_id')
+        .notNullable()
+        .references('trials.id');
+      table.enu('type', [
+        'csr',
+        'epar_segment',
+        'blank_consent_form',
+        'patient_information_sheet',
+        'blank_case_report_form',
+        'other',
+      ]).notNullable();
+      table.text('url')
+        .notNullable();
+
+      table.unique(['trial_id', 'url']);
+    })
+);
+
+exports.down = () => {
+  throw Error('Destructive migration can\'t be rolled back.');
+};

--- a/seeds/trials.js
+++ b/seeds/trials.js
@@ -252,6 +252,25 @@ exports.seed = (knex) => {
     },
   ];
 
+  const documents = [
+    {
+      id: '77b81059-19b2-4f5d-a00b-85b9c12b6002',
+      source_id: sources.nct.id,
+      trial_id: trials[0].id,
+      name: 'Blank Consent Form',
+      type: 'blank_consent_form',
+      url: 'http://example.com/consent_form.pdf',
+    },
+    {
+      id: 'e43a38cc-6a32-44f3-9f97-d4859fc6de47',
+      source_id: sources.isrctn.id,
+      trial_id: trials[0].id,
+      name: 'Clinical Study Report (CSR)',
+      type: 'csr',
+      url: 'http://example.com/csr.pdf',
+    },
+  ];
+
   // Records
   const records = [
     {
@@ -473,11 +492,13 @@ exports.seed = (knex) => {
     .then(() => knex('records').del())
     .then(() => knex('trials_publications').del())
     .then(() => knex('publications').del())
+    .then(() => knex('documents').del())
     .then(() => knex('trials').del())
     .then(() => knex('sources').del())
     // Insert
     .then(() => knex('sources').insert(_getEntries(sources)))
     .then(() => knex('trials').insert(trialsWithoutRelatedModels))
+    .then(() => knex('documents').insert(documents))
     .then(() => knex('locations').insert(_getEntries(locations)))
     .then(() => knex('trials_locations').insert(trialsLocations))
     .then(() => knex('interventions').insert(_getEntries(interventions)))

--- a/test/api/models/trial.js
+++ b/test/api/models/trial.js
@@ -26,6 +26,7 @@ describe('Trial', () => {
       'records.source',
       'publications',
       'publications.source',
+      'documents',
     ]);
   });
 

--- a/test/common.js
+++ b/test/common.js
@@ -21,7 +21,6 @@ function clearDB() {
     'trials_organisations',
     'organisations',
     'documents',
-    'trials_documents',
     'publications',
     'trials_publications',
     'records',


### PR DESCRIPTION
We had a `trials_documents` table to generate a many-to-many relationship
between trials and documents. However, a single document can't cite multiple
trials (AFAIK), so we can simplify that to a 1-to-many relationship. This means
we can remove the `trials_documents` table.

I also removed the `documents.slug` column, as we're not using it, and added
the `type` (e.g. csr, epar_segment, ...) and `url` columns. For now, the trials
endpoint returns an array of these documents with their `name`, `type` and
`url`.

opentrials/opentrials#254