### PR TITLE
[#301] Don't index entities not linked to trials

### DIFF
--- a/tools/create-trials-index.js
+++ b/tools/create-trials-index.js
@@ -299,6 +299,9 @@ function bulkIndexEntities(entities, index, indexType) {
   }
 
   const bulkBody = entities.models.reduce((result, entity) => {
+    if (entity.relations.trials && entity.relations.trials.length === 0) {
+      return result;
+    }
     const action = {
       index: {
         _index: index,
@@ -346,7 +349,12 @@ function indexModel(model, index, indexType, fetchOptions) {
 }
 
 function indexAutocompleteModel(model, indexType) {
-  return indexModel(model, 'autocomplete', indexType, { columns: ['id', 'name'] });
+  return indexModel(
+    model,
+    'autocomplete',
+    indexType,
+    { columns: ['id', 'name'], withRelated: 'trials' }
+  );
 }
 
 client.indices.delete({ index: 'trials', ignore: 404 })


### PR DESCRIPTION
After several iterations, I found this current implementation as being the fastest and more reliable of all the different ideas I had for it. No need for dedicated methods, helpers etc., as all our autocomplete models now have a relationship with trials.

~~Changed the console text a bit too, in order to reflect the total number that is just being processed for indexing, and not necessarily everything is going to be (re)indexed.~~ I tried to play with the console text a bit, but I managed to get eslint angry instead. :fearful: 