### PR TITLE
[#278] Ignore EUCTR records when calculating discrepancies

### DIFF
--- a/api/models/trial.js
+++ b/api/models/trial.js
@@ -117,7 +117,9 @@ const Trial = BaseModel.extend({
         'registration_date',
         'recruitment_status',
       ];
-      const records = this.related('records').toJSON();
+      const records = this.related('records')
+                          .toJSON()
+                          .filter((record) => record.source.id !== 'euctr');
       let discrepancies;
 
       for (const field of discrepancyFields) {

--- a/test/api/models/trial.js
+++ b/test/api/models/trial.js
@@ -332,6 +332,27 @@ describe('Trial', () => {
           .then(() => new Trial({ id: trial_id }).fetch({ withRelated: ['records', 'records.source'] }))
           .then((trial) => should(trial.discrepancies).be.undefined());
       });
+
+      it('ignores records from EU CTR', () => {
+        let trial_id;
+
+        return factory.create('trial')
+          .then((trial) => trial_id = trial.attributes.id)
+          .then(() => factory.create('source', { id: 'euctr' }))
+          .then((euctr) => factory.createMany('record', [
+              {
+                trial_id,
+                primary_source_id: euctr.id,
+                gender: 'female',
+              },
+              {
+                trial_id,
+                gender: 'both',
+              },
+           ]))
+          .then(() => new Trial({ id: trial_id }).fetch({ withRelated: ['records', 'records.source'] }))
+          .then((trial) => should(trial.discrepancies).be.undefined());
+      });
     });
   });
 });


### PR DESCRIPTION
They cause too much trouble because they have translations in different
languages, the `registration_date` is different for each country, the
`target_sample_size` is specific to each country, etc.. To avoid those, we'll
just ignore EUCTR completely for now.

Fixes opentrials/opentrials#278