### PR TITLE
Add ON DELETE CASCADE to all trials relationship tables

### DIFF
--- a/migrations/20160830191612_add_on_delete_cascade_to_trials_relationship_tables.js
+++ b/migrations/20160830191612_add_on_delete_cascade_to_trials_relationship_tables.js
@@ -1,0 +1,52 @@
+'use strict';
+
+exports.up = (knex) => {
+  function addOnDeleteCascade(schema, tableName, originalConstraintName) {
+    const constraint = `${tableName}_trial_id_foreign`;
+    const originalConstraint = originalConstraintName || constraint;
+
+    return schema.raw(`ALTER TABLE ${tableName}
+                       DROP CONSTRAINT ${originalConstraint},
+                       ADD CONSTRAINT ${constraint}
+                         FOREIGN KEY (trial_id)
+                         REFERENCES trials(id)
+                         ON DELETE CASCADE
+    `);
+  }
+
+  const schema = knex.schema;
+
+  addOnDeleteCascade(schema, 'trials_conditions', 'trials_problems_trial_id_foreign');
+  addOnDeleteCascade(schema, 'trials_interventions');
+  addOnDeleteCascade(schema, 'trials_locations');
+  addOnDeleteCascade(schema, 'trials_organisations');
+  addOnDeleteCascade(schema, 'trials_persons');
+  addOnDeleteCascade(schema, 'trials_publications');
+
+  return schema;
+};
+
+exports.down = (knex) => {
+  function removeOnDeleteCascade(schema, tableName, originalConstraintName) {
+    const constraint = `${tableName}_trial_id_foreign`;
+    const originalConstraint = originalConstraintName || constraint;
+
+    return schema.raw(`ALTER TABLE ${tableName}
+                       DROP CONSTRAINT ${constraint},
+                       ADD CONSTRAINT ${originalConstraint}
+                         FOREIGN KEY (trial_id)
+                         REFERENCES trials(id)
+    `);
+  }
+
+  const schema = knex.schema;
+
+  removeOnDeleteCascade(schema, 'trials_conditions', 'trials_problems_trial_id_foreign');
+  removeOnDeleteCascade(schema, 'trials_interventions');
+  removeOnDeleteCascade(schema, 'trials_locations');
+  removeOnDeleteCascade(schema, 'trials_organisations');
+  removeOnDeleteCascade(schema, 'trials_persons');
+  removeOnDeleteCascade(schema, 'trials_publications');
+
+  return schema;
+};


### PR DESCRIPTION
Added this only for the "trial_id", and not the other foreign keys (e.g.
publication_id on trials_publications) to be safer. Also, removing a trial with
all those different relations is cumbersome, but removing a (say) publication
isn't because we just need to remove the trials_publications referencing it.