### PR TITLE
[#364] Reduce memory usage of the reindexing process

### DIFF
--- a/tools/create-trials-index.js
+++ b/tools/create-trials-index.js
@@ -321,9 +321,9 @@ function bulkIndexEntities(entities, index, indexType) {
 
 function indexModel(model, index, indexType, _queryParams, fetchOptions) {
   return model.count().then((modelCount) => {
-    const bufferLength = 1000;
+    const batchSize = 1000;
     console.info(
-      `${modelCount} entities being indexed in "${index}/${indexType}" (${bufferLength} at a time).`
+      `${modelCount} entities being indexed in "${index}/${indexType}" (${batchSize} at a time).`
     );
     let offset = 0;
     let chain = Promise.resolve();
@@ -333,7 +333,7 @@ function indexModel(model, index, indexType, _queryParams, fetchOptions) {
         {},
         {
           orderBy: 'id',
-          limit: bufferLength,
+          limit: batchSize,
           offset,
         },
         _queryParams
@@ -347,7 +347,7 @@ function indexModel(model, index, indexType, _queryParams, fetchOptions) {
           console.info(`${count} successfully reindexed.`);
         });
 
-      offset = offset + bufferLength;
+      offset = offset + batchSize;
     } while (offset <= modelCount);
 
     return chain.catch(console.error);


### PR DESCRIPTION
I did so by offloading the removal of entities without trials to the database,
instead of doing it with NodeJS. With these changes, there's no need to query
for the actual trials as well, so it reduces the number of SQL queries in half.

I haven't tested the difference in memory usage, but considering we're both not
loading the trials in memory and loading just the entities we need, I'd imagine
it to be quite significant. Hopefully enough to avoid the Out of Memory errors
we're seeing.

Fixes opentrials/opentrials#364