### PR TITLE
[#382] Remove `url` from Locations API response

### DIFF
--- a/api/models/location.js
+++ b/api/models/location.js
@@ -17,11 +17,6 @@ const Location = BaseModel.extend({
     return this.belongsToMany('Trial', 'trials_locations',
       'location_id', 'trial_id').withPivot(['role']);
   },
-  virtuals: {
-    url: function () {
-      return helpers.urlFor(this);
-    },
-  },
   topLocations: function () {
     return bookshelf.knex
       .select(

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -487,13 +487,10 @@ definitions:
     required:
       - id
       - name
-      - url
     properties:
       id:
         type: string
       name:
-        type: string
-      url:
         type: string
       type:
         type: string

--- a/test/api/models/location.js
+++ b/test/api/models/location.js
@@ -40,11 +40,4 @@ describe('Location', () => {
         });
     });
   });
-
-  describe('url', () => {
-    it('returns the url', () => {
-      return factory.build('location')
-        .then((loc) => should(loc.toJSON().url).eql(helpers.urlFor(loc)));
-    });
-  });
 });


### PR DESCRIPTION
Locations have no `/v1/locations/<id>` route, so the URLs don't exist.

Fixes opentrials/opentrials#382