### PR TITLE
[#287] Swagger improvements

### DIFF
--- a/api/controllers/conditions.js
+++ b/api/controllers/conditions.js
@@ -21,5 +21,5 @@ function getCondition(req, res) {
 }
 
 module.exports = {
-  get: getCondition,
+  getCondition,
 }

--- a/api/controllers/interventions.js
+++ b/api/controllers/interventions.js
@@ -21,5 +21,5 @@ function getIntervention(req, res) {
 }
 
 module.exports = {
-  get: getIntervention,
+  getIntervention,
 }

--- a/api/controllers/organisations.js
+++ b/api/controllers/organisations.js
@@ -21,5 +21,5 @@ function getOrganisation(req, res) {
 }
 
 module.exports = {
-  get: getOrganisation,
+  getOrganisation,
 }

--- a/api/controllers/persons.js
+++ b/api/controllers/persons.js
@@ -21,5 +21,5 @@ function getPerson(req, res) {
 }
 
 module.exports = {
-  get: getPerson,
+  getPerson,
 }

--- a/api/controllers/publications.js
+++ b/api/controllers/publications.js
@@ -20,5 +20,5 @@ function getPublication(req, res) {
 }
 
 module.exports = {
-  get: getPublication,
+  getPublication,
 }

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -70,6 +70,6 @@ function autocomplete(req, res) {
 }
 
 module.exports = {
-  search: searchTrials,
+  searchTrials,
   autocomplete,
 };

--- a/api/controllers/stats.js
+++ b/api/controllers/stats.js
@@ -31,5 +31,5 @@ function getStats(req, res) {
 }
 
 module.exports = {
-  get: getStats,
+  getStats,
 }

--- a/api/controllers/trials.js
+++ b/api/controllers/trials.js
@@ -53,7 +53,7 @@ function getRecords(req, res) {
 }
 
 module.exports = {
-  get: getTrial,
+  getTrial,
   getRecord,
   getRecords,
 }

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -19,8 +19,14 @@ paths:
     get:
       tags:
         - trials
-      description: Search trials
-      operationId: search
+      description: Find trials using a simple keyword(s) based search. At the moment, operators (`AND`, `OR`)are not implemented. 
+                   If the results span across multiple pages, use the `page` parameter to request a specific page and `per_page` 
+                   to alter the number of results returned on a single page.
+                   
+                   - `page` can take a value between `1` and `100`
+                   
+                   - `per_page` can take a value between `10` and `100`
+      operationId: searchTrials
       parameters:
         - name: q
           in: query
@@ -55,9 +61,23 @@ paths:
     get:
       tags:
         - search
-      description: Search locations
+      description: Autocomplete search feature for supported database entities 
+                   (`condition`, `intervention`, `location`, `person`, `organisation`).
+                   It has the same options as a regular `search` operation, with an extra **required**
+                   `in` parameter indicating the entity type to search.
       operationId: autocomplete
       parameters:
+        - name: in
+          in: path
+          required: true
+          description: The entity to search for
+          type: string
+          enum:
+            - condition
+            - intervention
+            - location
+            - person
+            - organisation
         - name: q
           in: query
           description: The search query
@@ -76,17 +96,6 @@ paths:
           minimum: 10
           maximum: 100
           default: 20
-        - name: in
-          in: path
-          required: true
-          description: The entity to search for
-          type: string
-          enum:
-            - condition
-            - intervention
-            - location
-            - person
-            - organisation
       responses:
         "200":
           description: Success
@@ -102,8 +111,8 @@ paths:
     get:
       tags:
         - trials
-      description: Returns trial details
-      operationId: get
+      description: Returns a trial's details and related entities (e.g. `conditions`).
+      operationId: getTrial
       parameters:
         - name: id
           in: path
@@ -128,11 +137,11 @@ paths:
       tags:
         - publications
       description: Returns publication details
-      operationId: get
+      operationId: getPublication
       parameters:
         - name: id
           in: path
-          description: ID of the publictaion
+          description: ID of the publication
           required: true
           type: string
       responses:
@@ -141,7 +150,7 @@ paths:
           schema:
             $ref: "#/definitions/Publication"
         "404":
-          description: Publictaion not found
+          description: Publication not found
         default:
           description: Error
           schema:
@@ -153,7 +162,7 @@ paths:
       tags:
         - conditions
       description: Returns condition details
-      operationId: get
+      operationId: getCondition
       parameters:
         - name: id
           in: path
@@ -178,7 +187,7 @@ paths:
       tags:
         - organisations
       description: Returns organisation details
-      operationId: get
+      operationId: getOrganisation
       parameters:
         - name: id
           in: path
@@ -202,7 +211,7 @@ paths:
     get:
       tags:
         - trials
-      description: Returns all trial's raw records from its sources
+      description: Returns a trial's raw records from its sources
       operationId: getRecords
       parameters:
         - name: id
@@ -250,7 +259,7 @@ paths:
       tags:
         - persons
       description: Returns person details
-      operationId: get
+      operationId: getPerson
       parameters:
         - name: id
           in: path
@@ -275,7 +284,7 @@ paths:
       tags:
         - interventions
       description: Returns intervention details
-      operationId: get
+      operationId: getIntervention
       parameters:
         - name: id
           in: path
@@ -316,8 +325,8 @@ paths:
     get:
       tags:
         - statistics
-      description: Returns statistics
-      operationId: get
+      description: Returns statistics for the entire database
+      operationId: getStats
       responses:
         "200":
           description: Success
@@ -337,18 +346,22 @@ definitions:
         description: Trials count
       trialsPerSource:
         type: array
+        description: Array of objects containing counts of trials, grouped by source
         items:
           $ref: '#/definitions/TrialsPerSource'
       trialsPerYear:
         type: array
+        description: Array of objects containing counts of trials, grouped by year
         items:
           $ref: '#/definitions/TrialsPerYear'
       topLocations:
         type: array
+        description: Array of objects containing counts of trials, grouped by location
         items:
           $ref: '#/definitions/TopLocations'
       sourcesLatestUpdatedDate:
         type: array
+        description: Array of objects containing the available sources and their latest update date
         items:
           $ref: '#/definitions/SourcesLatestUpdatedDate'
 
@@ -370,6 +383,7 @@ definitions:
     properties:
       year:
         type: integer
+        description: Registration year for trials
       count:
         type: integer
         description: Number of trials in this year
@@ -379,8 +393,10 @@ definitions:
     properties:
       id:
         type: string
+        description: Location's ID
       name:
         type: string
+        description: Location's name
       count:
         type: integer
         description: Number of trials in this location
@@ -391,8 +407,10 @@ definitions:
     properties:
       id:
         type: string
+        description: Source's ID
       name:
         type: string
+        description: Source's name
       latest_updated_date:
         type: string
         description: Date this source was last updated
@@ -411,33 +429,43 @@ definitions:
     properties:
       id:
         type: string
+        description: ID of the trial
       source_id:
         type: string
+        description: ID of the trial's source
       identifiers:
         type: object
-        description: Object that maps the Trial's sources ids with its identifiers.
+        description: Object that maps the trial's sources ids with its identifiers.
       url:
         type: string
+        description: Source URL (where the trial was collected from)
       public_title:
         type: string
+        description: Title of the trial
       brief_summary:
         type: string
+        description: Summary of the trial
       target_sample_size:
         type: integer
         minimum: 0
+        description: Target sample size for the trial
       gender:
         type: string
+        description: Gender of the subjects of the trial
         enum:
           - both
           - male
           - female
       has_published_results:
         type: boolean
+        description: Trial has its results published (true/false)
       registration_date:
         type: string
+        description: Date the trial was registered
         format: date-time
       status:
         type: string
+        description: Completion status of the trial
         enum:
           - ongoing
           - withdrawn
@@ -447,6 +475,7 @@ definitions:
           - other
       recruitment_status:
         type: string
+        description: Recruitment status of the trial
         enum:
           - recruiting
           - not_recruiting
@@ -454,38 +483,47 @@ definitions:
           - other
       locations:
         type: array
+        description: Locations related to the trial
         items:
           $ref: '#/definitions/TrialLocation'
       interventions:
         type: array
+        description: Interventions related to the trial
         items:
           $ref: '#/definitions/Intervention'
       conditions:
         type: array
+        description: Conditions the trial refers to
         items:
           $ref: '#/definitions/Condition'
       persons:
         type: array
+        description: People related to the trial
         items:
           $ref: '#/definitions/TrialPerson'
       organisations:
         type: array
+        description: Organisations related to the trial
         items:
           $ref: '#/definitions/TrialOrganisation'
       records:
         type: array
+        description: (published) records of the trial
         items:
           $ref: '#/definitions/RecordSummary'
       publications:
         type: array
+        description: Publications referring the trial
         items:
           $ref: '#/definitions/PublicationSummary'
       discrepancies:
         type: object
+        description: Discrepancies in trial's details between different sources
         items:
           $ref: '#/definitions/Discrepancies'
       documents:
         type: array
+        description: Documents related to the trial
         items:
           $ref: '#/definitions/Document'
 
@@ -499,6 +537,7 @@ definitions:
             enum:
               - recruitment_countries
               - other
+    description: Location of a trial
 
   Location:
     required:
@@ -507,10 +546,13 @@ definitions:
     properties:
       id:
         type: string
+        description: ID of the location
       name:
         type: string
+        description: Name of the location
       type:
         type: string
+        description: Type of the location (country / city / other)
         enum:
           - country
           - city
@@ -524,12 +566,16 @@ definitions:
     properties:
       id:
         type: string
+        description: ID of the intervention
       name:
         type: string
+        description: Name of the intervention
       url:
         type: string
+        description: OpenTrials API URL of the intervention
       type:
         type: string
+        description: Type of the intervention (drug / other)
         enum:
           - drug
           - other
@@ -542,10 +588,13 @@ definitions:
     properties:
       id:
         type: string
+        description: ID of the condition
       name:
         type: string
+        description: Name of the condition
       url:
         type: string
+        description: OpenTrials API URL of the condition
 
   TrialPerson:
     allOf:
@@ -559,6 +608,8 @@ definitions:
               - public_queries
               - scientific_queries
               - other
+    description: People related to a trial
+
   Person:
     required:
       - id
@@ -567,14 +618,13 @@ definitions:
     properties:
       id:
         type: string
+        description: ID of the person
       name:
         type: string
+        description: Name of the person
       url:
         type: string
-      type:
-        type: string
-        enum:
-          - other
+        description: OpenTrials API URL of the person
 
   TrialOrganisation:
     allOf:
@@ -596,10 +646,13 @@ definitions:
     properties:
       id:
         type: string
+        description: ID of the organisation
       name:
         type: string
+        description: Name of the organisation
       url:
         type: string
+        description: OpenTrials API URL of the organisation
 
   RecordList:
     type: array
@@ -621,27 +674,36 @@ definitions:
     properties:
       id:
         type: string
+        description: ID of the record
       identifiers:
         type: object
-        description: Object that maps the Trial's sources ids with its identifiers.
+        description: Object that maps the trial's sources ids with its identifiers.
       source_id:
         type: string
+        description: ID of the record's source
       url:
         type: string
+        description: OpenTrials API URL of the record
       trial_id:
         type: string
+        description: ID of the trial referenced in the record
       trial_url:
         type: string
+        description: OpenTrials API URL of the trial referenced in the record
       source:
         $ref: '#/definitions/Source'
       source_url:
         type: string
+        description: URL of the record's source (where it was collected from)
       source_data:
         type: object
+        description: Data extracted from the source URL
       public_title:
         type: string
+        description: Title of the record
       status:
         type: string
+        description: Trial's status (e.g. ongoing, withdrawn, complete etc.)
         enum:
           - ongoing
           - withdrawn
@@ -651,6 +713,7 @@ definitions:
           - other
       recruitment_status:
         type: string
+        description: Trial's recruitment status (e.g. recruiting, unknown etc.)
         enum:
           - recruiting
           - not_recruiting
@@ -659,8 +722,10 @@ definitions:
       created_at:
         type: string
         format: date-time
+        description: Date When the record was created
       updated_at:
         type: string
+        description: Date When the record was updated
         format: date-time
 
   Publication:
@@ -674,6 +739,7 @@ definitions:
     properties:
       id:
         type: string
+        description: ID of the publication
       url:
         type: string
       source:


### PR DESCRIPTION
Changed:

* `operationId` was defined multiple times as `get`, which is invalid according to swagger standards. This was changed in both the API and client and both PRs should be merged at once. In the client, the `agent/*` code was modified to reflect the API changes.

Added:

* More documentation in the `description` tags of the entities