### PR TITLE
[#387] Add entity File that belongs to many Documents

### DIFF
--- a/api/models/document.js
+++ b/api/models/document.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('./file');
+
 const bookshelf = require('../../config').bookshelf;
 const BaseModel = require('./base');
 
@@ -8,10 +10,21 @@ const Document = BaseModel.extend({
   visible: [
     'type',
     'name',
-    'url',
-    'documentcloud_url',
-    'text',
   ],
+  file: function () {
+    return this.belongsTo('File');
+  },
+  virtuals: {
+    url: function () {
+      return this.related('file').toJSON().url;
+    },
+    documentcloud_id: function () {
+      return this.related('file').toJSON().documentcloud_id;
+    },
+    text: function () {
+      return this.related('file').toJSON().text;
+    },
+  },
 });
 
 module.exports = bookshelf.model('Document', Document);

--- a/api/models/file.js
+++ b/api/models/file.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const bookshelf = require('../../config').bookshelf;
+const BaseModel = require('./base');
+
+const File = BaseModel.extend({
+  tableName: 'files',
+  visible: [
+    'url',
+    'documentcloud_id',
+    'text',
+  ],
+});
+
+module.exports = bookshelf.model('File', File);

--- a/api/models/trial.js
+++ b/api/models/trial.js
@@ -25,6 +25,7 @@ const relatedModels = [
   'publications',
   'publications.source',
   'documents',
+  'documents.file',
 ];
 
 const Trial = BaseModel.extend({

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -779,7 +779,6 @@ definitions:
     required:
       - name
       - type
-      - url
     properties:
       name:
         type: string
@@ -796,7 +795,7 @@ definitions:
           - other
       url:
         type: string
-      documentcloud_url:
+      documentcloud_id:
         type: string
       text:
         type: string

--- a/migrations/20160907170328_create_files_belonging_to_many_documents.js
+++ b/migrations/20160907170328_create_files_belonging_to_many_documents.js
@@ -1,0 +1,33 @@
+'use strict';
+
+exports.up = (knex) => (
+  knex.schema
+    .createTable('files', (table) => {
+      table.uuid('id')
+        .primary();
+
+      table.text('documentcloud_id')
+        .nullable()
+        .unique();
+      table.text('sha1')
+        .notNullable()
+        .unique();
+      table.text('url')
+        .notNullable()
+        .unique();
+      table.text('text')
+        .nullable();
+    })
+    .table('documents', (table) => {
+      table.uuid('file_id')
+        .references('files.id');
+    })
+    .raw('ALTER TABLE documents ALTER COLUMN url DROP NOT NULL')
+);
+
+exports.down = (knex) => (
+  knex.schema
+    .table('documents', (table) => table.dropColumn('file_id'))
+    .raw('ALTER TABLE documents ALTER COLUMN url SET NOT NULL')
+    .dropTableIfExists('files')
+);

--- a/seeds/trials.js
+++ b/seeds/trials.js
@@ -250,11 +250,29 @@ exports.seed = (knex) => {
     },
   ];
 
+  const files = [
+    {
+      id: '93adc23a-75b9-11e6-8b77-86f30ca893d3',
+      documentcloud_id: '1-example-file',
+      sha1: '60b27f004e454aca81b0480209cce5081ec52390',
+      url: 'http://example.org/file1.pdf',
+      text: 'Lorem ipsum dolor sit amet',
+    },
+    {
+      id: '9e536a14-75b9-11e6-8b77-86f30ca893d3',
+      documentcloud_id: '2-example-file',
+      sha1: 'cb99b709a1978bd205ab9dfd4c5aaa1fc91c7523',
+      url: 'http://example.org/file2.pdf',
+      text: 'Sed ut perspiciatis unde omnis iste natus',
+    },
+  ];
+
   const documents = [
     {
       id: '77b81059-19b2-4f5d-a00b-85b9c12b6002',
       source_id: sources.nct.id,
       trial_id: trials[0].id,
+      file_id: files[0].id,
       name: 'Blank Consent Form',
       type: 'blank_consent_form',
       url: 'http://example.com/consent_form.pdf',
@@ -263,6 +281,7 @@ exports.seed = (knex) => {
       id: 'e43a38cc-6a32-44f3-9f97-d4859fc6de47',
       source_id: sources.isrctn.id,
       trial_id: trials[0].id,
+      file_id: files[1].id,
       name: 'Clinical Study Report (CSR)',
       type: 'csr',
       url: 'http://example.com/csr.pdf',
@@ -479,6 +498,7 @@ exports.seed = (knex) => {
 
   return knex('trials_locations').del()
     .then(() => knex('locations').del())
+    .then(() => knex('files').del())
     .then(() => knex('documents').del())
     .then(() => knex('trials_interventions').del())
     .then(() => knex('interventions').del())
@@ -508,6 +528,7 @@ exports.seed = (knex) => {
     .then(() => knex('trials_organisations').insert(trialsOrganisations))
     .then(() => knex('publications').insert(_getEntries(publications)))
     .then(() => knex('trials_publications').insert(trialsPublications))
+    .then(() => knex('files').insert(files))
     .then(() => knex('documents').insert(documents))
     .then(() => knex('records').insert(records));
 };

--- a/test/api/models/document.js
+++ b/test/api/models/document.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const should = require('should');
+const Document = require('../../../api/models/document');
+
+describe('Document', () => {
+  before(clearDB);
+
+  afterEach(clearDB);
+
+  describe('virtuals', () => {
+    describe('url', () => {
+      it('should delegate to its file', () => {
+        const url = 'http://example.com/myfilepath.pdf';
+
+        return factory.create('file', { url })
+          .then((file) => factory.create('document', { file_id: file.attributes.id }))
+          .then((doc) => new Document({ id: doc.attributes.id }).fetch({ withRelated: ['file'] }))
+          .then((doc) => should(doc.toJSON().url).equal(url));
+      })
+    });
+
+    describe('documentcloud_id', () => {
+      it('should delegate to its file', () => {
+        const dc_id = '1000-the-file';
+
+        return factory.create('file', { documentcloud_id: dc_id })
+          .then((file) => factory.create('document', { file_id: file.attributes.id }))
+          .then((doc) => new Document({ id: doc.attributes.id }).fetch({ withRelated: ['file'] }))
+          .then((doc) => should(doc.toJSON().documentcloud_id).equal(dc_id));
+      })
+    });
+
+    describe('text', () => {
+      it('should delegate to its file', () => {
+        const text = 'Sample text';
+
+        return factory.create('file', { text })
+          .then((file) => factory.create('document', { file_id: file.attributes.id }))
+          .then((doc) => new Document({ id: doc.attributes.id }).fetch({ withRelated: ['file'] }))
+          .then((doc) => should(doc.toJSON().text).equal(text));
+      })
+    });
+  });
+});

--- a/test/api/models/trial.js
+++ b/test/api/models/trial.js
@@ -27,6 +27,7 @@ describe('Trial', () => {
       'publications',
       'publications.source',
       'documents',
+      'documents.file',
     ]);
   });
 

--- a/test/common.js
+++ b/test/common.js
@@ -21,6 +21,7 @@ function clearDB() {
     'trials_organisations',
     'organisations',
     'documents',
+    'files',
     'publications',
     'trials_publications',
     'records',

--- a/test/factory.js
+++ b/test/factory.js
@@ -12,6 +12,8 @@ const Organisation = require('../api/models/organisation');
 const Source = require('../api/models/source');
 const Record = require('../api/models/record');
 const Publication = require('../api/models/publication');
+const Document = require('../api/models/document');
+const File = require('../api/models/file');
 
 factory.define('publication', Publication, {
   id: () => uuid.v1(),
@@ -62,6 +64,25 @@ factory.define('source', Source, {
   id: () => uuid.v1(),
   name: factory.sequence((n) => `source${n}`),
   type: 'register',
+});
+
+factory.define('file', File, {
+  id: () => uuid.v1(),
+  url: factory.sequence((n) => `http://example.org/file${n}.pdf`),
+  sha1: factory.sequence(),
+  documentcloud_id: factory.sequence((n) => `${n}-file`),
+  text: 'Lorem ipsum dolor sit amet',
+});
+
+factory.define('document', Document, {
+  id: () => uuid.v1(),
+  file_id: factory.assoc('file', 'id'),
+  source_id: factory.assoc('source', 'id'),
+  trial_id: factory.assoc('trial', 'id'),
+  url: factory.sequence((n) => `http://example.org/file${n}.pdf`),
+  documentcloud_url: factory.sequence((n) => `http://documentcloud.org/file${n}.pdf`),
+  name: factory.sequence((n) => `Document ${n}`),
+  type: 'other',
 });
 
 const trialAttributes = {


### PR DESCRIPTION
This extracts the attributes related to the actual file location and its text
from the `documents` table to a new `files` table. The reasoning behind it is
that multiple documents can (and do) reference the same file, so this
extraction will allow us to keep a single entry in our database in those cases.

I haven't removed the columns from the `documents` table yet because I want to
populate the `files` table with our current contents before that. After we run
this migration and populate the `files` table, we can add another migration to
remove the then redudant columns.

I also changed to use the "documentcloud_id" instead of its URL so we can
delete files from DocumentCloud as needed (e.g. when they're updated). This
isn't ideal, but we can generate a document's URL based on its ID.

The API changes in this pull request are needed just while we don't finish the
data migration. They will be reverted afterwards.

opentrials/opentrials#387