### PR TITLE
Fix seeds and make sure Travis catches these erros in the future

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ before_install:
 before_script:
   - psql -c 'create database opentrials_api_test;' -U postgres
   - npm run migrate
+  # Run seed twice to make sure we're cleaning the DB correctly
+  - npm run seed
   - npm run seed
   - npm run reindex
 script:

--- a/seeds/trials.js
+++ b/seeds/trials.js
@@ -498,8 +498,8 @@ exports.seed = (knex) => {
 
   return knex('trials_locations').del()
     .then(() => knex('locations').del())
-    .then(() => knex('files').del())
     .then(() => knex('documents').del())
+    .then(() => knex('files').del())
     .then(() => knex('trials_interventions').del())
     .then(() => knex('interventions').del())
     .then(() => knex('trials_conditions').del())


### PR DESCRIPTION
The problems happen when we delete/create tables in the wrong order and end up
with a Postgres error. This commit fixes the current seeds and run them twice
on Travis, so those mistakes will end up in a failed build.