### PR TITLE
Return all trial's sources metadata in trials.sources object

### DIFF
--- a/api/models/publication.js
+++ b/api/models/publication.js
@@ -31,7 +31,7 @@ const Publication = BaseModel.extend({
       id: attributes.id,
       url: attributes.url,
       title: attributes.title,
-      source: this.related('source').toJSON(),
+      source_id: this.attributes.source_id,
     };
 
     return result;

--- a/api/models/record.js
+++ b/api/models/record.js
@@ -40,7 +40,7 @@ const Record = BaseModel.extend({
     const attributes = this.toJSON();
     const result = {
       id: attributes.id,
-      source: this.related('source').toJSON(),
+      source_id: this.attributes.source_id,
     };
 
     if (attributes.url) {

--- a/api/models/trial.js
+++ b/api/models/trial.js
@@ -110,6 +110,28 @@ const Trial = BaseModel.extend({
     url: function () {
       return helpers.urlFor(this);
     },
+    sources: function () {
+      const publicationsSources = this.related('publications')
+                                      .toJSON()
+                                      .map((publication) => publication.source);
+      const recordsSources = this.related('records')
+                                 .toJSON()
+                                 .map((record) => record.source);
+      const sources = [...publicationsSources,
+                       ...recordsSources];
+
+      const result = sources.reduce((data, source) => {
+        data[source.id] = {
+          id: source.id,
+          name: source.name,
+          url: source.url,
+        };
+
+        return data;
+      }, {});
+
+      return result;
+    },
     discrepancies: function () {
       const discrepancyFields = [
         'target_sample_size',

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -408,6 +408,7 @@ definitions:
       - organisations
       - records
       - publications
+      - sources
     properties:
       id:
         type: string
@@ -488,6 +489,10 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Document'
+      sources:
+        type: object
+        items:
+          $ref: '#/definitions/Source'
 
   TrialLocation:
     allOf:
@@ -706,21 +711,21 @@ definitions:
     required:
       - id
       - url
-      - source
+      - source_id
     properties:
       id:
         type: string
       url:
         type: string
-      source:
-        $ref: '#/definitions/Source'
+      source_id:
+        type: string
 
   PublicationSummary:
     required:
       - id
       - url
       - title
-      - source
+      - source_id
     properties:
       id:
         type: string
@@ -728,8 +733,8 @@ definitions:
         type: string
       title:
         type: string
-      source:
-        $ref: '#/definitions/Source'
+      source_id:
+        type: string
 
   Discrepancies:
     description: Object listing the Trial's discrepant fields

--- a/seeds/trials.js
+++ b/seeds/trials.js
@@ -378,7 +378,7 @@ exports.seed = (knex) => {
     },
     {
       id: '2e3406c4-031f-11e6-b512-3e1d05defe78',
-      trial_id: trials[0].id,
+      trial_id: trials[1].id,
       source_id: sources.isrctn.id,
       source_url: 'http://www.isrctn.com/ISRCTN11631712',
       source_data: JSON.stringify({

--- a/test/api/models/publication.js
+++ b/test/api/models/publication.js
@@ -22,7 +22,7 @@ describe('Publication', () => {
           id: publication.attributes.id,
           url: publication.url,
           title: publication.attributes.title,
-          source: publication.related('source').toJSON(),
+          source_id: publication.attributes.source_id,
         });
       });
   });

--- a/test/api/models/record.js
+++ b/test/api/models/record.js
@@ -34,7 +34,7 @@ describe('Record', () => {
       const recordJSON = record.toJSON();
 
       record.toJSONSummary().should.deepEqual({
-        source: record.related('source').toJSON(),
+        source_id: record.attributes.source_id,
         id: recordJSON.id,
         url: recordJSON.url,
         source_url: recordJSON.source_url,

--- a/test/api/models/trial.js
+++ b/test/api/models/trial.js
@@ -246,6 +246,30 @@ describe('Trial', () => {
   });
 
   describe('virtuals', () => {
+    describe('sources', () => {
+      it('returns the publications sources', () => {
+        return factory.create('trialWithRelated')
+          .then((trial) => {
+            const publications = trial.related('publications');
+            const publicationsSourcesIds = publications.map((pub) => pub.attributes.source_id);
+            const sources = trial.toJSON().sources;
+
+            should(sources).have.keys(publicationsSourcesIds);
+          })
+      });
+
+      it('returns the records sources', () => {
+        return factory.create('trialWithRecord')
+          .then((trial) => {
+            const records = trial.related('records');
+            const recordsSourcesIds = records.map((rec) => rec.attributes.source_id);
+            const sources = trial.toJSON().sources;
+
+            should(sources).have.keys(recordsSourcesIds);
+          })
+      });
+    });
+
     describe('discrepancies', () => {
       it('returns the discrepancies', () => {
         let trial_id;

--- a/test/factory.js
+++ b/test/factory.js
@@ -23,7 +23,7 @@ factory.define('publication', Publication, {
   abstract: 'abstract',
   journal: 'some journal',
   date: new Date('2016-01-02'),
-  slug: 'some-slug',
+  slug: factory.sequence((n) => `slug-${n}`),
 }, {
   afterCreate: (publication, attrs, callback) => {
     new Publication({ id: publication.id })
@@ -104,6 +104,15 @@ const trialAttributes = {
 
 factory.define('trial', Trial, trialAttributes);
 
+factory.define('trialWithRecord', Trial, trialAttributes, {
+  afterCreate: (trial, options, callback) => {
+    factory.create('record', { trial_id: trial.id })
+    .then(() => new Trial({ id: trial.id }).fetch({ withRelated: Trial.relatedModels }))
+    .then((instance) => callback(null, instance))
+    .catch((err) => callback(err));
+  },
+});
+
 factory.define('trialWithRelated', Trial, trialAttributes, {
   afterCreate: (trial, options, callback) => {
     Promise.all([
@@ -133,6 +142,11 @@ factory.define('trialWithRelated', Trial, trialAttributes, {
           trial.organisations().attach({
             organisation_id: organisation.id,
             role: 'other',
+          })
+      )),
+      factory.create('publication').then((publication) => (
+          trial.publications().attach({
+            publication_id: publication.id,
           })
       )),
     ])


### PR DESCRIPTION
See https://github.com/opentrials/opentrials/issues/327 for the reasoning behind this.