### PR TITLE
Improve console messages for ES reindex

### DIFF
--- a/tools/create-trials-index.js
+++ b/tools/create-trials-index.js
@@ -327,6 +327,8 @@ function indexModel(model, index, indexType, _queryParams, fetchOptions) {
     );
     let offset = 0;
     let chain = Promise.resolve();
+    let done = 0;
+    let left = modelCount;
 
     do {
       const queryParams = Object.assign(
@@ -343,8 +345,10 @@ function indexModel(model, index, indexType, _queryParams, fetchOptions) {
         .then(() => model.query(queryParams).fetchAll(fetchOptions))
         .then((entities) => bulkIndexEntities(entities, index, indexType))
         .then((resp) => {
-          const count = (resp) ? resp.items.length : 0;
-          console.info(`${count} successfully reindexed.`);
+          let count = (resp) ? resp.items.length : 0;
+          left -= count;
+          done += count;
+          console.info(`${done} successfully reindexed (${left} remaining, ${count} at a time).`);
         });
 
       offset += batchSize;


### PR DESCRIPTION
I was getting tired of this

```
335032 entities being indexed in "trials/trial" (1000 at a time).
1000 successfully reindexed.
1000 successfully reindexed.
[...]
```

And I made it like this:

```
335032 entities being indexed in "trials/trial" (1000 at a time).
1000 successfully reindexed (334032 remaining, 1000 at a time).
2000 successfully reindexed (333032 remaining, 1000 at a time).
3000 successfully reindexed (332032 remaining, 1000 at a time).
4000 successfully reindexed (331032 remaining, 1000 at a time).
5000 successfully reindexed (330032 remaining, 1000 at a time).
6000 successfully reindexed (329032 remaining, 1000 at a time).
[...]
```

*Reason for doing this is that when you have a large database to index, chances are you'll only see `1000 successfully reindexed.` on your screen without having to scroll up/down.*


😎 