### PR TITLE
[#418] Limit memory usage when reindexing

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "seed": "knex seed:run",
     "start": "node --optimize_for_size --max_old_space_size=460 --gc_interval=100 server.js",
     "dev": "nodemon server.js",
-    "reindex": "node ./tools/create-trials-index.js"
+    "reindex": "node --optimize_for_size --max_old_space_size=460 --gc_interval=100 ./tools/create-trials-index.js"
   }
 }


### PR DESCRIPTION
NodeJS uses up to 1.5GB by default, but we only have 512MB available in Heroku.

Fixes opentrials/opentrials#418