### PR TITLE
[#429] A document must have a "url" or a "file_id", but not both

### DIFF
--- a/api/models/document.js
+++ b/api/models/document.js
@@ -10,14 +10,25 @@ const Document = BaseModel.extend({
   visible: [
     'type',
     'name',
+    'url',
   ],
   file: function () {
     return this.belongsTo('File');
   },
+  serialize: function (options) {
+    const attributes = Object.assign(
+      {},
+      Object.getPrototypeOf(Document.prototype).serialize.call(this, arguments)
+    );
+
+    const fileURL = this.related('file').toJSON().url;
+    if (fileURL) {
+      attributes.url = fileURL;
+    }
+
+    return attributes;
+  },
   virtuals: {
-    url: function () {
-      return this.related('file').toJSON().url;
-    },
     documentcloud_id: function () {
       return this.related('file').toJSON().documentcloud_id;
     },

--- a/migrations/20161001173327_add_url_to_documents_without_files.js
+++ b/migrations/20161001173327_add_url_to_documents_without_files.js
@@ -1,0 +1,29 @@
+'use strict';
+
+exports.up = (knex) => (
+  knex.schema
+    .table('documents', (table) => {
+      table.text('url');
+
+      table.unique([
+        'trial_id',
+        'file_id',
+        'fda_approval_id',
+        'url',
+      ]);
+    })
+    .raw('ALTER TABLE documents ALTER COLUMN file_id DROP NOT NULL')
+    .raw(`ALTER TABLE documents
+          ADD CONSTRAINT file_id_xor_url_check CHECK (
+          (file_id IS NULL AND url IS NOT NULL) OR
+          (file_id IS NOT NULL AND url IS NULL)
+    )`)
+);
+
+exports.down = (knex) => (
+  knex.schema
+    .table('documents', (table) => {
+      table.dropColumn('url');
+    })
+    .raw('ALTER TABLE documents ALTER COLUMN file_id SET NOT NULL')
+);

--- a/test/api/models/document.js
+++ b/test/api/models/document.js
@@ -8,24 +8,29 @@ describe('Document', () => {
 
   afterEach(clearDB);
 
+  describe('url', () => {
+    it('should return its own url if it has no file', () => {
+      return factory.create('document', { file_id: undefined })
+        .then((doc) => should(doc.toJSON().url).not.be.undefined());
+    })
+
+    it('should delegate to its file if it exists', () => {
+      const url = 'http://example.com/myfilepath.pdf';
+
+      return factory.create('file', { url })
+        .then((file) => factory.create('documentWithFile', { file_id: file.attributes.id }))
+        .then((doc) => new Document({ id: doc.attributes.id }).fetch({ withRelated: ['file'] }))
+        .then((doc) => should(doc.toJSON().url).equal(url));
+    })
+  });
+
   describe('virtuals', () => {
-    describe('url', () => {
-      it('should delegate to its file', () => {
-        const url = 'http://example.com/myfilepath.pdf';
-
-        return factory.create('file', { url })
-          .then((file) => factory.create('document', { file_id: file.attributes.id }))
-          .then((doc) => new Document({ id: doc.attributes.id }).fetch({ withRelated: ['file'] }))
-          .then((doc) => should(doc.toJSON().url).equal(url));
-      })
-    });
-
     describe('documentcloud_id', () => {
       it('should delegate to its file', () => {
         const dc_id = '1000-the-file';
 
         return factory.create('file', { documentcloud_id: dc_id })
-          .then((file) => factory.create('document', { file_id: file.attributes.id }))
+          .then((file) => factory.create('documentWithFile', { file_id: file.attributes.id }))
           .then((doc) => new Document({ id: doc.attributes.id }).fetch({ withRelated: ['file'] }))
           .then((doc) => should(doc.toJSON().documentcloud_id).equal(dc_id));
       })
@@ -36,7 +41,7 @@ describe('Document', () => {
         const text = 'Sample text';
 
         return factory.create('file', { text })
-          .then((file) => factory.create('document', { file_id: file.attributes.id }))
+          .then((file) => factory.create('documentWithFile', { file_id: file.attributes.id }))
           .then((doc) => new Document({ id: doc.attributes.id }).fetch({ withRelated: ['file'] }))
           .then((doc) => should(doc.toJSON().text).equal(text));
       })

--- a/test/factory.js
+++ b/test/factory.js
@@ -76,14 +76,29 @@ factory.define('file', File, {
   text: 'Lorem ipsum dolor sit amet',
 });
 
-factory.define('document', Document, {
+const documentAttributes = {
   id: () => uuid.v1(),
-  file_id: factory.assoc('file', 'id'),
   source_id: factory.assoc('source', 'id'),
   trial_id: factory.assoc('trial', 'id'),
   name: factory.sequence((n) => `Document ${n}`),
   type: 'other',
-});
+};
+
+factory.define('document', Document, Object.assign(
+  {},
+  documentAttributes,
+  {
+    url: factory.sequence((n) => `http://example.org/document${n}`),
+  }
+));
+
+factory.define('documentWithFile', Document, Object.assign(
+  {},
+  documentAttributes,
+  {
+    file_id: factory.assoc('file', 'id'),
+  }
+));
 
 const trialAttributes = {
   id: () => uuid.v1(),


### PR DESCRIPTION
A document doesn't need to be a file. It can be a webpage, for example.

Related to https://github.com/opentrials/processors/pull/66

Fixes opentrials/opentrials#429