### PR TITLE
[#457] Add explicit "type" in all swagger definitions

### DIFF
--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -314,7 +314,7 @@ paths:
         "200":
           description: Success
           schema:
-            $ref: "#/definitions/Source"
+            $ref: "#/definitions/SourceList"
         default:
           description: Error
           schema:
@@ -372,6 +372,7 @@ definitions:
         description: Date this source was last updated
 
   Trial:
+    type: object
     required:
       - id
       - url
@@ -494,6 +495,7 @@ definitions:
           $ref: '#/definitions/RiskOfBias'
 
   TrialLocation:
+    type: object
     allOf:
       - $ref: '#/definitions/Location'
       - type: object
@@ -506,6 +508,7 @@ definitions:
     description: Location of a trial
 
   Location:
+    type: object
     required:
       - id
       - name
@@ -525,6 +528,7 @@ definitions:
           - other
 
   Intervention:
+    type: object
     required:
       - id
       - name
@@ -547,6 +551,7 @@ definitions:
           - other
 
   Condition:
+    type: object
     required:
       - id
       - name
@@ -563,6 +568,7 @@ definitions:
         description: OpenTrials API URL of the condition
 
   TrialPerson:
+    type: object
     allOf:
       - $ref: '#/definitions/Person'
       - type: object
@@ -577,6 +583,7 @@ definitions:
     description: People related to a trial
 
   Person:
+    type: object
     required:
       - id
       - name
@@ -593,6 +600,7 @@ definitions:
         description: OpenTrials API URL of the person
 
   TrialOrganisation:
+    type: object
     allOf:
       - $ref: '#/definitions/Organisation'
       - type: object
@@ -605,6 +613,7 @@ definitions:
               - funder
               - other
   Organisation:
+    type: object
     required:
       - id
       - name
@@ -626,6 +635,7 @@ definitions:
       $ref: '#/definitions/Record'
 
   Record:
+    type: object
     required:
       - id
       - url
@@ -695,6 +705,7 @@ definitions:
         format: date-time
 
   Publication:
+    type: object
     required:
       - id
       - url
@@ -735,6 +746,7 @@ definitions:
         type: string
 
   RecordSummary:
+    type: object
     required:
       - id
       - url
@@ -748,6 +760,7 @@ definitions:
         type: string
 
   PublicationSummary:
+    type: object
     required:
       - id
       - url
@@ -767,6 +780,7 @@ definitions:
         type: string
 
   Discrepancies:
+    type: object
     description: Object listing the Trial's discrepant fields
     properties:
       gender:
@@ -791,6 +805,7 @@ definitions:
           $ref: '#/definitions/DiscrepantFieldBoolean'
 
   DiscrepantFieldString:
+    type: object
     allOf:
       - $ref: '#/definitions/DiscrepancyFieldBase'
       - type: object
@@ -799,6 +814,7 @@ definitions:
             type: string
 
   DiscrepantFieldInteger:
+    type: object
     allOf:
       - $ref: '#/definitions/DiscrepancyFieldBase'
       - type: object
@@ -807,6 +823,7 @@ definitions:
             type: integer
 
   DiscrepantFieldBoolean:
+    type: object
     allOf:
       - $ref: '#/definitions/DiscrepancyFieldBase'
       - type: object
@@ -815,6 +832,7 @@ definitions:
             type: boolean
 
   DiscrepancyFieldBase:
+    type: object
     required:
       - record_id
       - source_name
@@ -825,6 +843,7 @@ definitions:
         type: string
 
   Document:
+    type: object
     required:
       - name
       - type
@@ -851,6 +870,7 @@ definitions:
         type: string
 
   RiskOfBias:
+    type: object
     required:
       - id
       - source_id
@@ -871,6 +891,7 @@ definitions:
           $ref: '#/definitions/RiskOfBiasCriteria'
 
   RiskOfBiasCriteria:
+    type: object
     required:
       - id
       - name
@@ -887,7 +908,13 @@ definitions:
           - no
           - unknown
 
+  SourceList:
+    type: array
+    items:
+      $ref: '#/definitions/Source'
+
   Source:
+    type: object
     required:
       - id
       - name
@@ -908,6 +935,7 @@ definitions:
           - other
 
   TrialSearchResults:
+    type: object
     required:
       - total_count
       - items
@@ -920,6 +948,7 @@ definitions:
           $ref: '#/definitions/Trial'
 
   AutocompleteResults:
+    type: object
     required:
       - total_count
       - items
@@ -932,6 +961,7 @@ definitions:
           $ref: '#/definitions/AutocompleteResult'
 
   AutocompleteResult:
+    type: object
     required:
       - id
       - name
@@ -942,6 +972,7 @@ definitions:
         type: string
 
   ErrorResponse:
+    type: object
     required:
       - message
     properties:

--- a/test/api/controllers/search.js
+++ b/test/api/controllers/search.js
@@ -93,7 +93,7 @@ function basicSearchTests(url, factoryName) {
         hits: {
           total: 1,
           hits: [
-            { _source: JSON.stringify(factory.build(factoryName)) },
+            { _source: toJSON(factory.buildSync(factoryName)) },
           ],
         },
       };
@@ -102,7 +102,7 @@ function basicSearchTests(url, factoryName) {
 
       return server.inject(url)
         .then((response) => {
-          const items = esResult.hits.hits.map((hit) => hit._source);
+          const items = esResult.hits.hits.map((hit) => toJSON(hit._source));
 
           response.statusCode.should.equal(200);
           JSON.parse(response.result).should.deepEqual({

--- a/test/factory.js
+++ b/test/factory.js
@@ -119,7 +119,7 @@ factory.define('risk_of_bias_criteria', RiskOfBiasCriteria, {
 
 const trialAttributes = {
   id: () => uuid.v1(),
-  identifiers: JSON.stringify({}),
+  identifiers: {},
   registration_date: new Date('2016-01-01'),
   target_sample_size: 1000,
   gender: 'both',
@@ -128,7 +128,7 @@ const trialAttributes = {
   brief_summary: 'brief_summary',
   status: 'complete',
   recruitment_status: 'not_recruiting',
-  eligibility_criteria: JSON.stringify('[]'),
+  eligibility_criteria: [],
   study_type: 'study_type',
   study_design: 'study_design',
   study_phase: 'study_phase',
@@ -193,7 +193,7 @@ factory.define('record', Record, Object.assign({}, trialAttributes, {
   trial_id: factory.assoc('trial', 'id'),
   source_id: factory.assoc('source', 'id'),
   source_url: factory.sequence((n) => `http://source.com/trial/${n}`),
-  source_data: JSON.stringify({}),
+  source_data: {},
 }), {
   afterCreate: (record, attrs, callback) => {
     new Record({ id: record.id })


### PR DESCRIPTION
Python's Bravado (and possibly others) complains if we don't have explicit
types, even though the Swagger validator doesn't require one.

Fixes opentrials/opentrials#457