### PR TITLE
[#287] More details on the search query string

### DIFF
--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -23,6 +23,10 @@ paths:
                    If the results span across multiple pages, use the `page` parameter to request a specific page and `per_page`
                    to alter the number of results returned on a single page.
 
+                   - `q` can be a simple string search or an 
+                     [Elasticsearch query string](https://www.elastic.co/guide/en/elasticsearch/reference/2.3/query-dsl-query-string-query.html#query-string-syntax) 
+                     (e.g. `public_title:(depressive OR depression)`)
+
                    - `page` can take a value between `1` and `100`
 
                    - `per_page` can take a value between `10` and `100`
@@ -30,7 +34,7 @@ paths:
       parameters:
         - name: q
           in: query
-          description: The search query
+          description: The [search query](https://www.elastic.co/guide/en/elasticsearch/reference/2.3/query-dsl-query-string-query.html#query-string-syntax)
           type: string
         - name: page
           in: query

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -19,12 +19,10 @@ paths:
     get:
       tags:
         - trials
-      description: Find trials using a simple keyword(s) based search. At the moment, operators (`AND`, `OR`)are not implemented.
-                   If the results span across multiple pages, use the `page` parameter to request a specific page and `per_page`
-                   to alter the number of results returned on a single page.
+      description: Returns trials based on a search query. By default, it'll search in all of a trial's attributes.
 
-                   - `q` can be a simple string search or an 
-                     [Elasticsearch query string](https://www.elastic.co/guide/en/elasticsearch/reference/2.3/query-dsl-query-string-query.html#query-string-syntax) 
+                   - `q` is a [ElasticSearch query
+                     string](https://www.elastic.co/guide/en/elasticsearch/reference/2.3/query-dsl-query-string-query.html#query-string-syntax)
                      (e.g. `public_title:(depressive OR depression)`)
 
                    - `page` can take a value between `1` and `100`
@@ -34,7 +32,7 @@ paths:
       parameters:
         - name: q
           in: query
-          description: The [search query](https://www.elastic.co/guide/en/elasticsearch/reference/2.3/query-dsl-query-string-query.html#query-string-syntax)
+          description: The search query (follows the [ElasticSearch Query String](https://www.elastic.co/guide/en/elasticsearch/reference/2.3/query-dsl-query-string-query.html#query-string-syntax) syntax)
           type: string
         - name: page
           in: query


### PR DESCRIPTION
* Mention that `q` is an Elasticsearch query string

Fixes opentrials/opentrials#287