### PR TITLE
[#474] Improve /search endpoint performance

### DIFF
--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -28,7 +28,11 @@ function searchTrials(req, res) {
 
   return client.search(searchQuery)
     .then(_convertElasticSearchResult)
-    .then(res.json)
+    .then((data) => {
+      res.status(200);
+      res.setHeader('Content-Type', 'application/json');
+      return res.end(data);
+    })
     .catch((err) => {
       res.finish();
       throw err;


### PR DESCRIPTION
Using `res.json()` calls to `JSON.stringify()` on the response. As we're
getting the response from ElasticSearch, all fields are already converted to
JSON (there're no Date classes, for example), so there's no need to call
`JSON.stringify()`.

That reduces the response time in about 50%. You can check by using:
  ab -n 1000 -c 50 http://localhost:10010/v1/search

With and without this patch.

opentrials/opentrials#474