### PR TITLE
[#491] Create Elasticsearch aliases to use while reindexing

### DIFF
--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -34,8 +34,8 @@ function searchTrials(req, res) {
       return res.end(data);
     })
     .catch((err) => {
+      // FIXME: Log error and return 500 HTTP code
       res.finish();
-      throw err;
     });
 }
 
@@ -68,8 +68,8 @@ function autocomplete(req, res) {
     .then(_convertElasticSearchResult)
     .then(res.json)
     .catch((err) => {
+      // FIXME: Log error and return 500 HTTP code
       res.finish();
-      throw err;
     });
 }
 

--- a/config/bluebird.js
+++ b/config/bluebird.js
@@ -1,0 +1,5 @@
+'use strict';
+
+process.on('unhandledRejection', (reason) => {
+  throw reason;
+});

--- a/config/index.js
+++ b/config/index.js
@@ -12,6 +12,7 @@ const path = require('path');
 const good = require('good');
 const inert = require('inert');
 const httpAwsEs = require('http-aws-es');
+require('./bluebird');
 
 const config = {
   host: process.env.HOST || '0.0.0.0',

--- a/tools/create-trials-index.js
+++ b/tools/create-trials-index.js
@@ -2,6 +2,7 @@
 
 'use strict';
 
+const Promise = require('bluebird');
 const client = require('../config').elasticsearch;
 const _ = require('lodash');
 const Trial = require('../api/models/trial');
@@ -396,7 +397,8 @@ function getOldIndices(prefix, data) {
   return _.filter(_.keys(data), (k) => _.startsWith(k, prefix));
 }
 
-client.indices.getAliases()
+Promise.resolve() // Use bluebird promises
+  .then(() => client.indices.getAliases())
   .then((data) => {
     Array.prototype.push.apply(oldIndices, getOldIndices('trials', data));
     Array.prototype.push.apply(oldIndices, getOldIndices('autocomplete', data));
@@ -432,7 +434,4 @@ client.indices.getAliases()
     return result;
   })
   // Now we can exit
-  .then(() => process.exit())
-  .catch((err) => {
-    throw err;
-  });
+  .then(() => process.exit());


### PR DESCRIPTION
Modifications to reindexing script for zero downtime index (re)building process.

This builds a new index, then hot swaps an alias pointing to the existing one to the newly created indices for `trials` and `autocomplete`.

New index naming convention is;

* name of the index (e.g. `trials`)
* human readable date (e.g. `2016-10-17`)
* unique timestamp (e.g. `1476700588593`)
* all separated by underscore character (e.g. `trials_2016-10-17_1476700588593`)

There are currently two aliases: `trials` and `autocomplete` pointing to the newest corresponding index.

Fixes opentrials/opentrials#491