### PR TITLE
[#507] Modify trials/documents relationship to be n-to-m instead of 1-to-n

### DIFF
--- a/api/models/trial.js
+++ b/api/models/trial.js
@@ -105,7 +105,7 @@ const Trial = BaseModel.extend({
       'trial_id', 'publication_id');
   },
   documents: function () {
-    return this.hasMany('Document');
+    return this.belongsToMany('Document', 'trials_documents');
   },
   records: function () {
     return this.hasMany('Record');

--- a/migrations/20161020094503_add_trials_documents.js
+++ b/migrations/20161020094503_add_trials_documents.js
@@ -1,0 +1,25 @@
+'use strict';
+
+exports.up = (knex) => (
+  knex.schema
+    .createTable('trials_documents', (table) => {
+      table.uuid('trial_id')
+        .references('trials.id');
+      table.uuid('document_id')
+        .references('documents.id')
+        .index();
+
+      table.primary(['trial_id', 'document_id']);
+    })
+    .raw(`
+      INSERT INTO trials_documents (trial_id, document_id)
+      SELECT trial_id, id FROM documents
+    `)
+    .table('documents', (table) => {
+      table.dropColumn('trial_id');
+    })
+);
+
+exports.down = () => {
+  throw Error('Destructive migration can\'t be rolled back.');
+};

--- a/migrations/20161021092257_add_uniqueness_constraints_to_documents.js
+++ b/migrations/20161021092257_add_uniqueness_constraints_to_documents.js
@@ -1,0 +1,19 @@
+'use strict';
+
+exports.up = (knex) => (
+  knex.schema
+    .alterTable('documents', (table) => {
+      table.unique(['fda_approval_id', 'file_id', 'name']);
+      table.unique(['type', 'file_id']);
+      table.unique(['type', 'url']);
+    })
+);
+
+exports.down = (knex) => (
+  knex.schema
+    .alterTable('documents', (table) => {
+      table.dropUnique(['fda_approval_id', 'file_id', 'name']);
+      table.dropUnique(['type', 'file_id']);
+      table.dropUnique(['type', 'url']);
+    })
+);

--- a/seeds/trials.js
+++ b/seeds/trials.js
@@ -147,6 +147,39 @@ exports.seed = (knex) => {
     },
   };
 
+  const files = [
+    {
+      id: '93adc23a-75b9-11e6-8b77-86f30ca893d3',
+      documentcloud_id: '1-example-file',
+      sha1: '60b27f004e454aca81b0480209cce5081ec52390',
+      url: 'http://example.org/file1.pdf',
+      text: 'Lorem ipsum dolor sit amet',
+    },
+    {
+      id: '9e536a14-75b9-11e6-8b77-86f30ca893d3',
+      documentcloud_id: '2-example-file',
+      sha1: 'cb99b709a1978bd205ab9dfd4c5aaa1fc91c7523',
+      url: 'http://example.org/file2.pdf',
+      text: 'Sed ut perspiciatis unde omnis iste natus',
+    },
+  ];
+
+  const documents = [
+    {
+      id: '77b81059-19b2-4f5d-a00b-85b9c12b6002',
+      source_id: sources.nct.id,
+      file_id: files[0].id,
+      name: 'Blank Consent Form',
+      type: 'blank_consent_form',
+    },
+    {
+      id: 'e43a38cc-6a32-44f3-9f97-d4859fc6de47',
+      source_id: sources.isrctn.id,
+      file_id: files[1].id,
+      name: 'Clinical Study Report (CSR)',
+      type: 'csr',
+    },
+  ];
 
   const trials = [
     {
@@ -211,6 +244,11 @@ exports.seed = (knex) => {
           role: 'primary_sponsor',
         },
       ],
+      documents: [
+        {
+          document: documents[0],
+        },
+      ],
     },
     {
       id: '475456f3-23bc-4f5e-9d19-51f4a1165540',
@@ -257,42 +295,11 @@ exports.seed = (knex) => {
           role: 'primary_sponsor',
         },
       ],
-    },
-  ];
-
-  const files = [
-    {
-      id: '93adc23a-75b9-11e6-8b77-86f30ca893d3',
-      documentcloud_id: '1-example-file',
-      sha1: '60b27f004e454aca81b0480209cce5081ec52390',
-      url: 'http://example.org/file1.pdf',
-      text: 'Lorem ipsum dolor sit amet',
-    },
-    {
-      id: '9e536a14-75b9-11e6-8b77-86f30ca893d3',
-      documentcloud_id: '2-example-file',
-      sha1: 'cb99b709a1978bd205ab9dfd4c5aaa1fc91c7523',
-      url: 'http://example.org/file2.pdf',
-      text: 'Sed ut perspiciatis unde omnis iste natus',
-    },
-  ];
-
-  const documents = [
-    {
-      id: '77b81059-19b2-4f5d-a00b-85b9c12b6002',
-      source_id: sources.nct.id,
-      trial_id: trials[0].id,
-      file_id: files[0].id,
-      name: 'Blank Consent Form',
-      type: 'blank_consent_form',
-    },
-    {
-      id: 'e43a38cc-6a32-44f3-9f97-d4859fc6de47',
-      source_id: sources.isrctn.id,
-      trial_id: trials[0].id,
-      file_id: files[1].id,
-      name: 'Clinical Study Report (CSR)',
-      type: 'csr',
+      documents: [
+        {
+          document: documents[1],
+        },
+      ],
     },
   ];
 
@@ -540,6 +547,7 @@ exports.seed = (knex) => {
   const trialsPersons = _generateRelationships(trials, 'person');
   const trialsOrganisations = _generateRelationships(trials, 'organisation');
   const trialsPublications = _generateRelationships(trials, 'publication');
+  const trialsDocuments = _generateRelationships(trials, 'document');
 
   const trialsWithoutRelatedModels = trials.map((trial) => {
     const result = Object.assign({}, trial);
@@ -549,12 +557,14 @@ exports.seed = (knex) => {
     delete result.persons;
     delete result.organisations;
     delete result.publications;
+    delete result.documents;
 
     return result;
   });
 
   return knex('trials_locations').del()
     .then(() => knex('locations').del())
+    .then(() => knex('trials_documents').del())
     .then(() => knex('documents').del())
     .then(() => knex('files').del())
     .then(() => knex('trials_interventions').del())
@@ -590,6 +600,7 @@ exports.seed = (knex) => {
     .then(() => knex('trials_publications').insert(trialsPublications))
     .then(() => knex('files').insert(files))
     .then(() => knex('documents').insert(documents))
+    .then(() => knex('trials_documents').insert(trialsDocuments))
     .then(() => knex('risk_of_biases').insert(riskOfBiases))
     .then(() => knex('risk_of_bias_criterias').insert(riskOfBiasCriterias))
     .then(() => knex('risk_of_biases_risk_of_bias_criterias').insert(riskOfBiasesriskOfBiasCriterias))

--- a/test/common.js
+++ b/test/common.js
@@ -20,6 +20,7 @@ function clearDB() {
     'persons',
     'trials_organisations',
     'organisations',
+    'trials_documents',
     'documents',
     'files',
     'publications',

--- a/test/factory.js
+++ b/test/factory.js
@@ -81,7 +81,6 @@ factory.define('file', File, {
 const documentAttributes = {
   id: () => uuid.v1(),
   source_id: factory.assoc('source', 'id'),
-  trial_id: factory.assoc('trial', 'id'),
   name: factory.sequence((n) => `Document ${n}`),
   type: 'other',
 };
@@ -179,6 +178,11 @@ factory.define('trialWithRelated', Trial, trialAttributes, {
       factory.create('publication').then((publication) => (
           trial.publications().attach({
             publication_id: publication.id,
+          })
+      )),
+      factory.create('document').then((doc) => (
+          trial.documents().attach({
+            document_id: doc.id,
           })
       )),
     ])


### PR DESCRIPTION
I also modified the uniqueness constraints on the documents table, to make sure we're not adding duplicated documents in our database (check the commit message for background on the reasoning). For FDA documents, I had to add the document `name` to the unique constraint, which makes it somewhat fragile (as names can change). I created issue https://github.com/opentrials/opentrials/issues/518 to discuss our options and, depending on that, we might be able to remove the `name` from the constraint in the future.

Related to https://github.com/opentrials/processors/pull/73.

opentrials/opentrials#507