### PR TITLE
Fix documents uniqueness constraints

### DIFF
--- a/migrations/20161021092257_add_uniqueness_constraints_to_documents.js
+++ b/migrations/20161021092257_add_uniqueness_constraints_to_documents.js
@@ -4,16 +4,26 @@ exports.up = (knex) => (
   knex.schema
     .alterTable('documents', (table) => {
       table.unique(['fda_approval_id', 'file_id', 'name']);
-      table.unique(['type', 'file_id']);
-      table.unique(['type', 'url']);
     })
+    .raw(`
+      CREATE UNIQUE INDEX
+      non_fda_documents_type_file_id_unique
+      ON documents (type, file_id)
+      WHERE fda_approval_id IS NULL
+    `)
+    .raw(`
+      CREATE UNIQUE INDEX
+      non_fda_documents_type_url_unique
+      ON documents (type, url)
+      WHERE fda_approval_id IS NULL
+    `)
 );
 
 exports.down = (knex) => (
   knex.schema
     .alterTable('documents', (table) => {
       table.dropUnique(['fda_approval_id', 'file_id', 'name']);
-      table.dropUnique(['type', 'file_id']);
-      table.dropUnique(['type', 'url']);
     })
+    .raw('DROP INDEX non_fda_documents_type_file_id_unique')
+    .raw('DROP INDEX non_fda_documents_type_url_unique')
 );

--- a/migrations/20161024144543_rename_documents_files_and_sources_url_to_source_url.js
+++ b/migrations/20161024144543_rename_documents_files_and_sources_url_to_source_url.js
@@ -3,7 +3,7 @@
 exports.up = (knex) => (
   knex.schema
     .table('documents', (table) => table.renameColumn('url', 'source_url'))
-    .raw('ALTER TABLE documents RENAME CONSTRAINT documents_type_url_unique TO documents_type_source_url_unique')
+    .raw('ALTER INDEX non_fda_documents_type_url_unique RENAME TO non_fda_documents_type_source_url_unique')
     .raw('ALTER TABLE documents RENAME CONSTRAINT file_id_xor_url_check TO file_id_xor_source_url_check')
 
     .table('files', (table) => table.renameColumn('url', 'source_url'))
@@ -15,7 +15,7 @@ exports.up = (knex) => (
 exports.down = (knex) => (
   knex.schema
     .table('documents', (table) => table.renameColumn('source_url', 'url'))
-    .raw('ALTER TABLE documents RENAME CONSTRAINT documents_type_source_url_unique TO documents_type_url_unique')
+    .raw('ALTER INDEX non_fda_documents_type_source_url_unique RENAME TO non_fda_documents_type_url_unique')
     .raw('ALTER TABLE documents RENAME CONSTRAINT file_id_xor_source_url_check TO file_id_xor_url_check')
 
     .table('files', (table) => table.renameColumn('source_url', 'url'))


### PR DESCRIPTION
We should never alter migrations, but I realized the ones we have now will not
work on production. The problem is that our uniqueness constraints are
different for FDA documents and non-FDA documents. This is a very clear signal
that we should have a separate FDA document entity (see
opentrials/opentrials#521). We don't have it now, so this is the best we can
do.