### PR TITLE
[#425] Return all sources for a trial

### DIFF
--- a/api/controllers/documents.js
+++ b/api/controllers/documents.js
@@ -33,9 +33,9 @@ function listDocuments(req, res) {
       withRelated: Document.relatedModels,
     })
     .then((documents) => {
-      let response = {
+      const response = {
         total_count: documents.pagination.rowCount,
-        items: documents.models,
+        items: documents.models.map((m) => m.toJSONSummary()),
       }
       res.json(response);
     })

--- a/api/models/document.js
+++ b/api/models/document.js
@@ -5,21 +5,23 @@ require('./file');
 const helpers = require('../helpers');
 const bookshelf = require('../../config').bookshelf;
 const BaseModel = require('./base');
+const Source = require('./source');
 const relatedModels = [
   'file',
   'trials',
+  'source',
 ]
 
 const Document = BaseModel.extend({
   tableName: 'documents',
   visible: [
     'id',
-    'source_id',
     'name',
     'type',
-    'trials',
+    'source_url',
     'file',
-    'url',
+    'trials',
+    'source',
   ],
   serialize: function (options) {
     const attributes = Object.assign(
@@ -42,21 +44,28 @@ const Document = BaseModel.extend({
   trials: function () {
     return this.belongsToMany('Trial', 'trials_documents');
   },
+  source: function () {
+    return this.belongsTo('Source');
+  },
   toJSONSummary: function () {
     const attributes = this.attributes;
     const fileURL = this.related('file').toJSON().source_url;
 
     const result = {
+      id: attributes.id,
       name: attributes.name,
       type: attributes.type,
+      source_id: attributes.source_id,
       source_url:  attributes.source_url,
       documentcloud_id: this.documentcloud_id,
+      url: this.url,
       text: this.text,
     };
 
     if (fileURL) {
       result.source_url = fileURL;
     }
+
     return result;
   },
   virtuals: {

--- a/api/models/trial.js
+++ b/api/models/trial.js
@@ -27,6 +27,7 @@ const relatedModels = [
   'publications.source',
   'documents',
   'documents.file',
+  'documents.source',
   'risks_of_bias',
   'risks_of_bias.risk_of_bias_criteria',
 ];
@@ -130,10 +131,14 @@ const Trial = BaseModel.extend({
       const publicationsSources = this.related('publications')
                                       .toJSON()
                                       .map((publication) => publication.source);
+      const documentsSources = this.related('documents')
+                                 .toJSON()
+                                 .map((document) => document.source);
       const recordsSources = this.related('records')
                                  .toJSON()
                                  .map((record) => record.source);
       const sources = [...publicationsSources,
+                       ...documentsSources,
                        ...recordsSources];
 
       const result = sources.reduce((data, source) => {
@@ -144,6 +149,7 @@ const Trial = BaseModel.extend({
         };
 
         return data;
+
       }, {});
 
       return result;

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -1018,6 +1018,9 @@ definitions:
       file:
         type: object
         $ref: '#/definitions/FileSummary'
+      source:
+        type: object
+        $ref: '#/definitions/Source'
 
   DocumentList:
     type: object

--- a/test/api/models/document.js
+++ b/test/api/models/document.js
@@ -12,13 +12,20 @@ describe('Document', () => {
     it('returns simplified document representation', () => {
       return factory.create('file')
         .then((file) => factory.create('documentWithFile', { file_id: file.attributes.id }))
-        .then((doc) => doc.toJSONSummary().should.deepEqual({
-          name: doc.attributes.name,
-          type: doc.attributes.type,
-          source_url: doc.related('file').toJSON().source_url,
-          documentcloud_id: doc.documentcloud_id,
-          text: doc.text,
-        }));
+        .then((doc) => {
+          const attributes = doc.toJSON();
+
+          doc.toJSONSummary().should.deepEqual({
+            id: attributes.id,
+            name: attributes.name,
+            url: attributes.url,
+            type: attributes.type,
+            source_id: doc.attributes.source_id,
+            source_url: doc.related('file').toJSON().source_url,
+            documentcloud_id: doc.attributes.documentcloud_id,
+            text: attributes.text,
+          })
+        });
     });
 
     it('should return its own source_url if it has no file', () => {

--- a/test/api/models/trial.js
+++ b/test/api/models/trial.js
@@ -28,6 +28,7 @@ describe('Trial', () => {
       'publications.source',
       'documents',
       'documents.file',
+      'documents.source',
       'risks_of_bias',
       'risks_of_bias.risk_of_bias_criteria',
     ]);
@@ -278,6 +279,17 @@ describe('Trial', () => {
             const sources = trial.toJSON().sources;
 
             should(sources).have.keys(publicationsSourcesIds);
+          })
+      });
+
+      it('returns the documents sources', () => {
+        return factory.create('trialWithRelated')
+          .then((trial) => {
+            const documents = trial.related('documents');
+            const documentsSourcesIds = documents.map((doc) => doc.attributes.source_id);
+            const sources = trial.toJSON().sources;
+
+            should(sources).have.keys(documentsSourcesIds);
           })
       });
 

--- a/tools/create-trials-index.js
+++ b/tools/create-trials-index.js
@@ -413,6 +413,9 @@ Promise.resolve() // Use bluebird promises
   .then(() => indexAutocompleteModel(Location, autocompleteNewIndexName, 'location'))
   .then(() => indexAutocompleteModel(Person, autocompleteNewIndexName, 'person'))
   .then(() => indexAutocompleteModel(Organisation, autocompleteNewIndexName, 'organisation'))
+  // Remove `trials` index, if it exists, to avoid a name conflict with the alias
+  .then(() => client.indices.delete({ index: 'trials', ignore: 404 }))
+  .then(() => client.indices.delete({ index: 'autocomplete', ignore: 404 }))
   // Autocomplete is populated
   .then(() => client.indices.updateAliases({
     body: {


### PR DESCRIPTION
Warning: this introduces a breaking change on the returned sources list for a trial, which is now an array on unique elements as opposed to a hash keyed by `source_id`.

The `sources` virtual now also collects sources from `documents` and adds them to the list.

Swagger definitions and tests modified accordingly.

**Note:** I'm quite happy for moving towards lists of things that are actually sets/arrays, which is likely more predictable from an user's PoV. I wouldn't really expect `trial.sources` to give me back an object :)

**Note 2:** Special attention to be paid by reviewer to the other potentially overlooked usages of `sources` ex-object, now array, throughout the code. If something is missing, it won't be observable from the PR diff alone.