### PR TITLE
[#499] Remove extra fields from DocumentSummary and allow null source_id

### DIFF
--- a/api/controllers/documents.js
+++ b/api/controllers/documents.js
@@ -35,7 +35,7 @@ function listDocuments(req, res) {
     .then((documents) => {
       const response = {
         total_count: documents.pagination.rowCount,
-        items: documents.models.map((m) => m.toJSONSummary()),
+        items: documents.models,
       }
       res.json(response);
     })

--- a/api/models/document.js
+++ b/api/models/document.js
@@ -57,9 +57,7 @@ const Document = BaseModel.extend({
       type: attributes.type,
       source_id: attributes.source_id,
       source_url:  attributes.source_url,
-      documentcloud_id: this.documentcloud_id,
       url: this.url,
-      text: this.text,
     };
 
     if (fileURL) {

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -969,9 +969,53 @@ definitions:
 
   DocumentSummary:
     type: object
+    required:
+      - id
+      - name
+      - url
+      - type
     properties:
+      id:
+        type: string
       name:
         type: string
+      url:
+        type: string
+        description: OpenTrials API URL of the document
+      type:
+        type: string
+        enum:
+          - csr
+          - csr_synopsis
+          - epar_segment
+          - blank_consent_form
+          - patient_information_sheet
+          - blank_case_report_form
+          - results
+          - other
+      source_id:
+        type: string
+        description: ID of the document's source
+      source_url:
+        type: string
+        description: URL of origin for this document or its file
+
+  Document:
+    type: object
+    required:
+      - id
+      - name
+      - url
+      - type
+    properties:
+      id:
+        type: string
+        description: ID of the document
+      name:
+        type: string
+      url:
+        type: string
+        description: OpenTrials API URL of the document
       type:
         type: string
         enum:
@@ -986,31 +1030,12 @@ definitions:
       source_url:
         type: string
         description: URL of origin for this document or its file
-      documentcloud_id:
-        type: string
-        description: DocumentCloud ID of this document's file
       text:
         type: string
         description: Text of this document's file
-
-  Document:
-    type: object
-    required:
-      - id
-      - name
-      - url
-    properties:
-      id:
+      documentcloud_id:
         type: string
-        description: ID of the document
-      source_id:
-        type: string
-        description: ID of the document's source
-      name:
-        type: string
-      url:
-        type: string
-        description: OpenTrials API URL of the document
+        description: DocumentCloud ID of this document's file
       trials:
         type: array
         items:

--- a/test/api/controllers/documents.js
+++ b/test/api/controllers/documents.js
@@ -46,7 +46,7 @@ describe('Document', () => {
 
           const expectedResult = {
             total_count: 1,
-            items: [doc.toJSONSummary()],
+            items: [doc.toJSON()],
           }
           const result = JSON.parse(response.result);
           result.should.deepEqual(expectedResult);

--- a/test/api/models/document.js
+++ b/test/api/models/document.js
@@ -22,8 +22,6 @@ describe('Document', () => {
             type: attributes.type,
             source_id: doc.attributes.source_id,
             source_url: doc.related('file').toJSON().source_url,
-            documentcloud_id: doc.attributes.documentcloud_id,
-            text: attributes.text,
           })
         });
     });


### PR DESCRIPTION
We have some documents without `source_id` that came from data contributions.
We'll change them to include the original sources, but while we don't do that,
we need to allow nullable fields.

opentrials/opentrials#499

Related to opentrials/opentrials#530