### PR TITLE
[#527] Fix API crash on exception

### DIFF
--- a/config/bluebird.js
+++ b/config/bluebird.js
@@ -1,5 +1,5 @@
 'use strict';
 
 process.on('unhandledRejection', (reason) => {
-  throw reason;
+  console.trace(reason);
 });


### PR DESCRIPTION
Remove throwing on bluebird exception and trace to console as a
temporary solution.

Fixes opentrials/opentrials#527