### PR TITLE
[#542] Remove the schemes accepted in the Swagger definition

### DIFF
--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -3,9 +3,6 @@ info:
   version: "0.0.1"
   title: OpenTrials API
 basePath: /v1
-schemes:
-  - http
-  - https
 consumes:
   - application/json
 produces:

--- a/app.json
+++ b/app.json
@@ -16,7 +16,7 @@
       "options": {
         "version": "9.4"
       }
-    }
+    },
     {
       "plan": "bonsai:sandbox",
       "options": {

--- a/server.js
+++ b/server.js
@@ -39,8 +39,10 @@ function startServer() {
     if (err) { throw err; }
 
     const port = config.port;
-    const plugins = [swaggerHapi.plugin,
-                     ...config.hapi.plugins];
+    const plugins = [
+      swaggerHapi.plugin,
+      ...config.hapi.plugins,
+    ];
 
     server.connection({
       host: config.host,


### PR DESCRIPTION
The current problem is that the swagger clients are trying to load the API
using HTTP, instead of HTTPS. If that's on client-side, as it is on the swagger
docs page, the browser blocks those requests because they're "insecure" (mixed
content).

We could change the scheme to be HTTPS-only, but then it'll break local
development, as we don't use HTTPS while developing it on our local machines.

By removing the schemes, Swagger will use the same scheme as the one used to
load the Swagger definition. In other words, if you load the `swagger.yaml` via
HTTPS (like in production), it'll use HTTPS; if you load it via HTTP (like in
development), it'll use HTTP.

Fixes opentrials/opentrials#542