### PR TITLE
[#543] Fix bug with `trial.sources` when its documents have no source

### DIFF
--- a/api/models/trial.js
+++ b/api/models/trial.js
@@ -143,11 +143,13 @@ const Trial = BaseModel.extend({
                        ...recordsSources];
 
       const result = sources.reduce((data, source) => {
-        data[source.id] = {
-          id: source.id,
-          name: source.name,
-          source_url: source.source_url,
-        };
+        if (source !== undefined) {
+          data[source.id] = {
+            id: source.id,
+            name: source.name,
+            source_url: source.source_url,
+          };
+        }
 
         return data;
 

--- a/test/api/models/trial.js
+++ b/test/api/models/trial.js
@@ -303,6 +303,18 @@ describe('Trial', () => {
             should(sources).have.keys(recordsSourcesIds);
           })
       });
+
+      it('ignores documents without sources', () => {
+        return factory.create('trial')
+          .then((trial) => factory.create('document', { source_id: null })
+            .then((doc) => trial.documents().attach({
+              document_id: doc.id,
+            }))
+            .then(() => trial.id)
+          )
+          .then((trial_id) => new Trial({ id: trial_id }).fetch({ withRelated: ['documents', 'documents.source'] }))
+          .then((trial) => should(trial.toJSON().sources).deepEqual({}))
+      });
     });
 
     describe('discrepancies', () => {


### PR DESCRIPTION
`document.source_id` is nullable for now. It'll change in the future (see
opentrials/opentrials#530), but for now we need to solve this bug.

Fixes opentrials/opentrials#543