### PR TITLE
[#544] Add Risk of Bias sources to trial

### DIFF
--- a/api/models/document.js
+++ b/api/models/document.js
@@ -15,7 +15,7 @@ const relatedModels = [
   'source',
   'fda_approval',
   'fda_approval.fda_application',
-]
+];
 
 const Document = BaseModel.extend({
   tableName: 'documents',
@@ -42,7 +42,7 @@ const Document = BaseModel.extend({
       attributes.source_url = attributes.file.source_url;
     }
 
-    return attributes
+    return attributes;
   },
   file: function () {
     return this.belongsTo('File');

--- a/api/models/risk_of_bias.js
+++ b/api/models/risk_of_bias.js
@@ -2,7 +2,7 @@
 
 require('./source');
 require('./trial');
-require('./risk_of_bias_criteria')
+require('./risk_of_bias_criteria');
 
 const bookshelf = require('../../config').bookshelf;
 const BaseModel = require('./base');
@@ -14,12 +14,16 @@ const RiskOfBias = BaseModel.extend({
     'id',
     'trial_id',
     'source_id',
-    'study_id',
     'source_url',
+    'study_id',
     'risk_of_bias_criteria',
     'created_at',
     'updated_at',
+    'source',
   ],
+  source: function () {
+    return this.belongsTo('Source', 'source_id');
+  },
   risk_of_bias_criteria: function() {
     return this.belongsToMany('RiskOfBiasCriteria', 'risk_of_biases_risk_of_bias_criterias',
       'risk_of_bias_id', 'risk_of_bias_criteria_id').withPivot(['value']);

--- a/api/models/trial.js
+++ b/api/models/trial.js
@@ -31,6 +31,7 @@ const relatedModels = [
   'documents.fda_approval',
   'documents.fda_approval.fda_application',
   'risks_of_bias',
+  'risks_of_bias.source',
   'risks_of_bias.risk_of_bias_criteria',
 ];
 
@@ -137,14 +138,19 @@ const Trial = BaseModel.extend({
                                       .toJSON()
                                       .map((publication) => publication.source);
       const documentsSources = this.related('documents')
-                                 .toJSON()
-                                 .map((document) => document.source);
+                                   .toJSON()
+                                   .map((doc) => doc.source);
       const recordsSources = this.related('records')
                                  .toJSON()
                                  .map((record) => record.source);
+      const robSources = this.related('risks_of_bias')
+                             .toJSON()
+                             .map((rob) => rob.source);
+
       const sources = [...publicationsSources,
                        ...documentsSources,
-                       ...recordsSources];
+                       ...recordsSources,
+                       ...robSources];
 
       const result = sources.reduce((data, source) => {
         if (source !== undefined) {

--- a/test/api/models/trial.js
+++ b/test/api/models/trial.js
@@ -32,6 +32,7 @@ describe('Trial', () => {
       'documents.fda_approval',
       'documents.fda_approval.fda_application',
       'risks_of_bias',
+      'risks_of_bias.source',
       'risks_of_bias.risk_of_bias_criteria',
     ]);
   });


### PR DESCRIPTION
Fixes opentrials/opentrials#544

Fix for getting the Risk of Bias sources into the `trial.sources` virtual.