### PR TITLE
[#557] Index one document at a time

### DIFF
--- a/tools/indexers/fda_documents.js
+++ b/tools/indexers/fda_documents.js
@@ -177,7 +177,8 @@ function indexerPages(name) {
     {
       withRelated: ['file'],
     },
-    _convertDocumentsFilesPages
+    _convertDocumentsFilesPages,
+    1
   )
 }
 

--- a/tools/indexers/helpers.js
+++ b/tools/indexers/helpers.js
@@ -3,12 +3,15 @@
 const Promise = require('bluebird');
 const client = require('../../config').elasticsearch;
 
-const batchSize = 1000;
+const defaultBatchSize = 1000;
 
-function indexModel(model, index, indexType, _queryParams, fetchOptions, entitiesConverter) {
+function indexModel(model, index, indexType, _queryParams, fetchOptions, entitiesConverter, batchSize) {
   let converter = entitiesConverter;
-  if (converter == undefined) {
+  if (converter === undefined) {
     converter = (entities) => entities;
+  }
+  if (batchSize === undefined) {
+    batchSize = defaultBatchSize;
   }
 
   return model.query(_queryParams).count().then((modelCount) => {


### PR DESCRIPTION
The documents can be quite big, so we need to go over them one per one to try
to avoid RequestEntityTooLarge errors.

Fixes opentrials/opentrials#557