### PR TITLE
Fix FDA search bug on documents with empty pages

### DIFF
--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -48,10 +48,17 @@ function _convertFDADocumentsElasticSearchResult(esResult) {
 
       if (hit.inner_hits.page !== undefined) {
         const pages = hit.inner_hits.page.hits.hits;
-        doc.file.pages = pages.map((page) => ({
-          text: page.highlight.text[0],
-          num: page._source.num,
-        }));
+        doc.file.pages = pages.map((page) => {
+          let text = page._source.text;
+          if (page.highlight !== undefined && page.highlight.text.length > 0) {
+            text = page.highlight.text[0];
+          }
+
+          return {
+            text,
+            num: page._source.num,
+          }
+        });
       }
 
       return doc;


### PR DESCRIPTION
When a document has an empty page (i.e. `""`), ElasticSearch doesn't return the `highlights` attribute. In that case, we need to use the text from the page's `_source` instead.