### PR TITLE
Add correct trial.completion_date mapping

### DIFF
--- a/tools/indexers/trials.js
+++ b/tools/indexers/trials.js
@@ -293,6 +293,10 @@ const trialMapping = {
       type: 'date',
       format: 'dateOptionalTime',
     },
+    completion_date: {
+      type: 'date',
+      format: 'dateOptionalTime',
+    },
   },
 };
 


### PR DESCRIPTION
Without this, ElasticSearch uses a different mapping that requires dates on the
format 2016-01-01 (don't accept dates like 2016-1-1). This is different from
what we have on `trials.registration_date`, so is surprising to our users.