### PR TITLE
Sort FDA documents by application and date

### DIFF
--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -110,7 +110,6 @@ function searchFDADocuments(req, res) {
     from: (page - 1) * perPage,
     size: perPage,
     sort: [
-      '_score:desc',
       'application_id:desc',
       'fda_approval.supplement_number:desc',
       'name:asc',


### PR DESCRIPTION
The results from the same application should be together, ordered by date. As
we're sorting descending by application number, the newer applications (with
higher numbers) will appear first.