### PR TITLE
[#586] Fix wrong dates due to offset of time

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -63,6 +63,28 @@ bookshelf.plugin('virtuals');
 bookshelf.plugin('pagination');
 config.bookshelf = bookshelf;
 
+// Overwrite node-pg-types date parser. See https://github.com/tgriesser/knex/issues/1750
+const pgTypes = require('pg').types;
+
+function parseDate(val) {
+  return new Date(Date.parse(val));
+}
+function parseDateArray(value) {
+  if (!value) { return null; }
+
+  const p = pgTypes.arrayParser.create(value, (entry) => {
+    let parsedEntry = entry;
+    if (entry !== null) {
+      parsedEntry = parseDate(entry);
+    }
+    return parsedEntry;
+  });
+
+  return p.parse();
+}
+pgTypes.setTypeParser(1082, parseDate);
+pgTypes.setTypeParser(1182, parseDateArray);
+
 // ElasticSearch
 const elasticsearchConfig = {
   host: process.env.ELASTICSEARCH_URL,

--- a/config/index.js
+++ b/config/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 require('dotenv').config();
+require('./pg_types');
 
 if (!process.env.ELASTICSEARCH_URL) {
   // Fallback to BONSAI_URL if ELASTICSEARCH_URL isn't set.
@@ -62,28 +63,6 @@ bookshelf.plugin('visibility');
 bookshelf.plugin('virtuals');
 bookshelf.plugin('pagination');
 config.bookshelf = bookshelf;
-
-// Overwrite node-pg-types date parser. See https://github.com/tgriesser/knex/issues/1750
-const pgTypes = require('pg').types;
-
-function parseDate(val) {
-  return new Date(Date.parse(val));
-}
-function parseDateArray(value) {
-  if (!value) { return null; }
-
-  const p = pgTypes.arrayParser.create(value, (entry) => {
-    let parsedEntry = entry;
-    if (entry !== null) {
-      parsedEntry = parseDate(entry);
-    }
-    return parsedEntry;
-  });
-
-  return p.parse();
-}
-pgTypes.setTypeParser(1082, parseDate);
-pgTypes.setTypeParser(1182, parseDateArray);
 
 // ElasticSearch
 const elasticsearchConfig = {

--- a/config/pg_types.js
+++ b/config/pg_types.js
@@ -19,7 +19,7 @@ function parseDateArray(value) {
     return null;
   }
 
-  const p = pgTypes.arrayParser.create(value, (entry) => {
+  const parser = pgTypes.arrayParser.create(value, (entry) => {
     let parsedEntry = entry;
     if (String(entry).toLowerCase() !== String(null)) {
       parsedEntry = parseDate(entry);
@@ -29,7 +29,7 @@ function parseDateArray(value) {
     return parsedEntry;
   });
 
-  return p.parse();
+  return parser.parse();
 }
 
 pgTypes.setTypeParser(DATE_OID, parseDate);

--- a/config/pg_types.js
+++ b/config/pg_types.js
@@ -1,0 +1,41 @@
+'use strict';
+
+// Overwrite node-pg-types date parser. See https://github.com/tgriesser/knex/issues/1750
+const pgTypes = require('pg').types;
+
+const DATE_OID = 1082;
+const DATE_ARRAY_OID = 1182;
+
+function parseDate(value) {
+  let date;
+
+  if (isNaN(Date.parse(value)) === true) {
+    if (!value) {
+      date = null;
+    } else {
+      throw new Error('Invalid Date');
+    }
+  } else {
+    date = new Date(value);
+  }
+  return date;
+}
+
+function parseDateArray(value) {
+  if (!value) {
+    return null;
+  }
+
+  const p = pgTypes.arrayParser.create(value, (entry) => {
+    let parsedEntry = entry;
+    if (entry !== null) {
+      parsedEntry = parseDate(entry);
+    }
+    return parsedEntry;
+  });
+
+  return p.parse();
+}
+
+pgTypes.setTypeParser(DATE_OID, parseDate);
+pgTypes.setTypeParser(DATE_ARRAY_OID, parseDateArray);

--- a/config/pg_types.js
+++ b/config/pg_types.js
@@ -7,18 +7,11 @@ const DATE_OID = 1082;
 const DATE_ARRAY_OID = 1182;
 
 function parseDate(value) {
-  let date;
-
-  if (isNaN(Date.parse(value)) === true) {
-    if (!value) {
-      date = null;
-    } else {
-      throw new Error('Invalid Date');
-    }
-  } else {
-    date = new Date(value);
+  if (!value) {
+    return null;
   }
-  return date;
+
+  return new Date(Date.parse(value));
 }
 
 function parseDateArray(value) {
@@ -28,8 +21,10 @@ function parseDateArray(value) {
 
   const p = pgTypes.arrayParser.create(value, (entry) => {
     let parsedEntry = entry;
-    if (entry !== null) {
+    if (String(entry).toLowerCase() !== String(null)) {
       parsedEntry = parseDate(entry);
+    } else {
+      parsedEntry = null;
     }
     return parsedEntry;
   });

--- a/test/api/models/trial.js
+++ b/test/api/models/trial.js
@@ -436,21 +436,4 @@ describe('Trial', () => {
         }));
     });
   });
-
-  describe('registration_date', () => {
-    it('does not offset time', () => {
-      let trial_id;
-      const trialAttributes = {
-        registration_date: new Date('2016-09-12'),
-      };
-
-      return factory.create('trial', trialAttributes)
-        .then((trial) => trial_id = trial.attributes.id)
-        .then(() => new Trial({ id: trial_id }).fetch())
-        .then((savedTrial) => {
-          let savedDate = savedTrial.attributes.registration_date.toISOString();
-          savedDate.should.equal(trialAttributes.registration_date.toISOString());
-        });
-    });
-  });
 });

--- a/test/api/models/trial.js
+++ b/test/api/models/trial.js
@@ -436,4 +436,21 @@ describe('Trial', () => {
         }));
     });
   });
+
+  describe('registration_date', () => {
+    it('does not offset time', () => {
+      let trial_id;
+      const trialAttributes = {
+        registration_date: new Date('2016-09-12'),
+      };
+
+      return factory.create('trial', trialAttributes)
+        .then((trial) => trial_id = trial.attributes.id)
+        .then(() => new Trial({ id: trial_id }).fetch())
+        .then((savedTrial) => {
+          let savedDate = savedTrial.attributes.registration_date.toISOString();
+          savedDate.should.equal(trialAttributes.registration_date.toISOString());
+        });
+    });
+  });
 });

--- a/test/config/pg_types.js
+++ b/test/config/pg_types.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const should = require('should');
+const pgTypes = require('pg').types;
+const customTypes = require('../../config/pg_types');
+
+describe('parseDate', () => {
+  const DATE_OID = 1082;
+
+  it('does not offset time', () => {
+    let testDate = '2016-12-01';
+    let expectedDate = new Date(testDate).toISOString();
+    let resultedDate = pgTypes.getTypeParser(DATE_OID)(testDate);
+    resultedDate.toISOString().should.equal(expectedDate);
+  });
+
+  it('returns null when value is null', () => {
+    let testDate = null;
+    should.equal(pgTypes.getTypeParser(DATE_OID)(testDate), null);
+  });
+
+  it('raises when value is invalid', () => {
+    let testDate = 'not a date';
+    pgTypes.getTypeParser(DATE_OID).bind(null, testDate).should.throw(/^Invalid Date/);
+  })
+});
+
+describe('parseDateArray', () => {
+  const DATE_ARRAY_OID = 1182;
+
+  it('parses array correctly', () => {
+    let testDate = '2014-01-12';
+    let testArray = `{${testDate}}`;
+    let expectedDate = new Date(testDate).toISOString();
+    let resultedArray = pgTypes.getTypeParser(DATE_ARRAY_OID)(testArray);
+    resultedArray.map((date) => date.toISOString()).should.containEql(expectedDate);
+  });
+
+  it('returns null when value is null', () => {
+    let testArray = null;
+    should.equal(pgTypes.getTypeParser(DATE_ARRAY_OID)(testArray), null);
+  });
+
+  it('returns empty array when there are no values', () => {
+    let testArray = `{}`;
+    let resultedArray = pgTypes.getTypeParser(DATE_ARRAY_OID)(testArray);
+    resultedArray.should.be.empty;
+  });
+
+  it('raises when one of the values is invalid', () => {
+    let testArray = `{2016-07-08, null}`;
+    pgTypes.getTypeParser(DATE_ARRAY_OID).bind(null, testArray).should.throw(/^Invalid Date/);
+  });
+});

--- a/test/config/pg_types.js
+++ b/test/config/pg_types.js
@@ -28,27 +28,27 @@ describe('parseDateArray', () => {
 
   it('parses array correctly', () => {
     let testDate = '2014-01-12';
-    let testArray = `{${testDate}}`;
+    let testPgArray = `{${testDate}}`;
     let expectedDate = new Date(testDate).toISOString();
-    let resultedArray = parseDateArray(testArray);
+    let resultedArray = parseDateArray(testPgArray);
     resultedArray.map((date) => date.toISOString()).should.deepEqual([
       expectedDate,
     ]);
   });
 
   it('returns null when value is null', () => {
-    let testArray = null;
-    should(parseDateArray(testArray)).equal(null);
+    let testPgArray = null;
+    should(parseDateArray(testPgArray)).equal(null);
   });
 
   it('returns empty array when there are no values', () => {
-    let testArray = `{}`;
-    parseDateArray(testArray).should.be.empty();
+    let testPgArray = `{}`;
+    parseDateArray(testPgArray).should.be.empty();
   });
 
   it('returns null for the null values', () => {
-    let testArray = `{null}`;
-    parseDateArray(testArray).should.deepEqual([
+    let testPgArray = `{null}`;
+    parseDateArray(testPgArray).should.deepEqual([
       null,
     ]);
   });

--- a/test/config/pg_types.js
+++ b/test/config/pg_types.js
@@ -6,49 +6,50 @@ const customTypes = require('../../config/pg_types');
 
 describe('parseDate', () => {
   const DATE_OID = 1082;
+  const parseDate = pgTypes.getTypeParser(DATE_OID);
 
   it('does not offset time', () => {
     let testDate = '2016-12-01';
     let expectedDate = new Date(testDate).toISOString();
-    let resultedDate = pgTypes.getTypeParser(DATE_OID)(testDate);
+    let resultedDate = parseDate(testDate);
     resultedDate.toISOString().should.equal(expectedDate);
   });
 
   it('returns null when value is null', () => {
     let testDate = null;
-    should.equal(pgTypes.getTypeParser(DATE_OID)(testDate), null);
+    should(parseDate(testDate)).equal(null);
   });
 
-  it('raises when value is invalid', () => {
-    let testDate = 'not a date';
-    pgTypes.getTypeParser(DATE_OID).bind(null, testDate).should.throw(/^Invalid Date/);
-  })
 });
 
 describe('parseDateArray', () => {
   const DATE_ARRAY_OID = 1182;
+  const parseDateArray = pgTypes.getTypeParser(DATE_ARRAY_OID);
 
   it('parses array correctly', () => {
     let testDate = '2014-01-12';
     let testArray = `{${testDate}}`;
     let expectedDate = new Date(testDate).toISOString();
-    let resultedArray = pgTypes.getTypeParser(DATE_ARRAY_OID)(testArray);
-    resultedArray.map((date) => date.toISOString()).should.containEql(expectedDate);
+    let resultedArray = parseDateArray(testArray);
+    resultedArray.map((date) => date.toISOString()).should.deepEqual([
+      expectedDate,
+    ]);
   });
 
   it('returns null when value is null', () => {
     let testArray = null;
-    should.equal(pgTypes.getTypeParser(DATE_ARRAY_OID)(testArray), null);
+    should(parseDateArray(testArray)).equal(null);
   });
 
   it('returns empty array when there are no values', () => {
     let testArray = `{}`;
-    let resultedArray = pgTypes.getTypeParser(DATE_ARRAY_OID)(testArray);
-    resultedArray.should.be.empty;
+    parseDateArray(testArray).should.be.empty();
   });
 
-  it('raises when one of the values is invalid', () => {
-    let testArray = `{2016-07-08, null}`;
-    pgTypes.getTypeParser(DATE_ARRAY_OID).bind(null, testArray).should.throw(/^Invalid Date/);
+  it('returns null for the null values', () => {
+    let testArray = `{null}`;
+    parseDateArray(testArray).should.deepEqual([
+      null,
+    ]);
   });
 });


### PR DESCRIPTION
opentrials/opentrials#686

After a charming journey among the horrors of JS date handling, this is the best thing I could come up with.
Imho expressed in [this node-pg-types issue](https://github.com/brianc/node-pg-types/issues/50), the `Date`-only fields should **not** have any time information attached to them. However, seems that most JS developers (including the ones at `node-elasticsearch`) don't share my opinion so I had to settle with this for consistency.