### PR TITLE
Adjust the garbage collector to reduce memory footprint

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "migrate": "knex migrate:latest",
     "seed": "knex seed:run",
-    "start": "node --optimize_for_size --max_old_space_size=460 --gc_interval=100 server.js",
+    "start": "node --optimize_for_size --max_old_space_size=400 --gc_interval=100 server.js",
     "dev": "nodemon server.js",
     "reindex": "node --optimize_for_size --max_old_space_size=460 --gc_interval=100 ./tools/reindex.js"
   }


### PR DESCRIPTION
Attempting to reduce the issues we have with memory load on the API. Step one is to slightly adjust the way Node's GC works and observe if there is any impact.