### PR TITLE
[#529] Fix running linter

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+/coverage/**

--- a/api/controllers/conditions.js
+++ b/api/controllers/conditions.js
@@ -5,7 +5,7 @@ const Condition = require('../models/condition');
 function getCondition(req, res) {
   const id = req.swagger.params.id.value;
 
-  return new Condition({ id: id }).fetch({})
+  return new Condition({ id }).fetch({})
     .then((condition) => {
       if (condition) {
         res.json(condition);
@@ -22,4 +22,4 @@ function getCondition(req, res) {
 
 module.exports = {
   getCondition,
-}
+};

--- a/api/controllers/documents.js
+++ b/api/controllers/documents.js
@@ -5,9 +5,9 @@ const Document = require('../models/document');
 function getDocument(req, res) {
   const id = req.swagger.params.id.value;
 
-  return new Document({ id: id }).fetch({
-      withRelated: Document.relatedModels,
-    })
+  return new Document({ id }).fetch({
+    withRelated: Document.relatedModels,
+  })
     .then((doc) => {
       if (doc) {
         res.json(doc);
@@ -28,15 +28,15 @@ function listDocuments(req, res) {
   const perPage = params.per_page.value;
 
   return Document.fetchPage({
-      page: page,
-      pageSize: perPage,
-      withRelated: Document.relatedModels,
-    })
+    page,
+    pageSize: perPage,
+    withRelated: Document.relatedModels,
+  })
     .then((documents) => {
       const response = {
         total_count: documents.pagination.rowCount,
         items: documents.models.map((m) => m.toJSONSummary()),
-      }
+      };
       res.json(response);
     })
     .catch((err) => {
@@ -48,4 +48,4 @@ function listDocuments(req, res) {
 module.exports = {
   getDocument,
   listDocuments,
-}
+};

--- a/api/controllers/fda_applications.js
+++ b/api/controllers/fda_applications.js
@@ -5,12 +5,12 @@ const FDAApplication = require('../models/fda_application');
 function getFDAApplication(req, res) {
   const id = req.swagger.params.id.value;
 
-  return new FDAApplication({ id: id }).fetch({
-      withRelated: FDAApplication.relatedModels,
-    })
-    .then((fda_application) => {
-      if (fda_application) {
-        res.json(fda_application);
+  return new FDAApplication({ id }).fetch({
+    withRelated: FDAApplication.relatedModels,
+  })
+    .then((fdaApplication) => {
+      if (fdaApplication) {
+        res.json(fdaApplication);
       } else {
         res.status(404);
         res.finish();
@@ -28,15 +28,15 @@ function listFDAApplications(req, res) {
   const perPage = params.per_page.value;
 
   return FDAApplication.fetchPage({
-      page: page,
-      pageSize: perPage,
-      withRelated: FDAApplication.relatedModels,
-    })
-    .then((fda_applications) => {
-      let response = {
-        total_count: fda_applications.pagination.rowCount,
-        items: fda_applications.models,
-      }
+    page,
+    pageSize: perPage,
+    withRelated: FDAApplication.relatedModels,
+  })
+    .then((fdaApplications) => {
+      const response = {
+        total_count: fdaApplications.pagination.rowCount,
+        items: fdaApplications.models,
+      };
       res.json(response);
     })
     .catch((err) => {
@@ -48,4 +48,4 @@ function listFDAApplications(req, res) {
 module.exports = {
   getFDAApplication,
   listFDAApplications,
-}
+};

--- a/api/controllers/interventions.js
+++ b/api/controllers/interventions.js
@@ -5,7 +5,7 @@ const Intervention = require('../models/intervention');
 function getIntervention(req, res) {
   const id = req.swagger.params.id.value;
 
-  return new Intervention({ id: id }).fetch({})
+  return new Intervention({ id }).fetch({})
     .then((intervention) => {
       if (intervention) {
         res.json(intervention);
@@ -22,4 +22,4 @@ function getIntervention(req, res) {
 
 module.exports = {
   getIntervention,
-}
+};

--- a/api/controllers/organisations.js
+++ b/api/controllers/organisations.js
@@ -5,7 +5,7 @@ const Organisation = require('../models/organisation');
 function getOrganisation(req, res) {
   const id = req.swagger.params.id.value;
 
-  return new Organisation({ id: id }).fetch({})
+  return new Organisation({ id }).fetch({})
     .then((organisation) => {
       if (organisation) {
         res.json(organisation);
@@ -22,4 +22,4 @@ function getOrganisation(req, res) {
 
 module.exports = {
   getOrganisation,
-}
+};

--- a/api/controllers/persons.js
+++ b/api/controllers/persons.js
@@ -5,7 +5,7 @@ const Person = require('../models/person');
 function getPerson(req, res) {
   const id = req.swagger.params.id.value;
 
-  return new Person({ id: id }).fetch({})
+  return new Person({ id }).fetch({})
     .then((person) => {
       if (person) {
         res.json(person);
@@ -22,4 +22,4 @@ function getPerson(req, res) {
 
 module.exports = {
   getPerson,
-}
+};

--- a/api/controllers/publications.js
+++ b/api/controllers/publications.js
@@ -4,7 +4,7 @@ const Publication = require('../models/publication');
 
 function getPublication(req, res) {
   const id = req.swagger.params.id.value;
-  return new Publication({ id: id }).fetch({ withRelated: Publication.relatedModels })
+  return new Publication({ id }).fetch({ withRelated: Publication.relatedModels })
     .then((publication) => {
       if (publication) {
         res.json(publication);
@@ -21,4 +21,4 @@ function getPublication(req, res) {
 
 module.exports = {
   getPublication,
-}
+};

--- a/api/controllers/search.js
+++ b/api/controllers/search.js
@@ -57,7 +57,7 @@ function _convertFDADocumentsElasticSearchResult(esResult) {
           return {
             text,
             num: page._source.num,
-          }
+          };
         });
       }
 
@@ -150,7 +150,7 @@ function searchFDADocuments(req, res) {
               },
             },
           ],
-        }
+        },
       },
     },
   };
@@ -188,11 +188,11 @@ function autocomplete(req, res) {
           name: params.q.value,
         },
       },
-    }
+    };
   } else {
     // Return all results
     searchQuery.q = undefined;
-  };
+  }
 
   return client.search(searchQuery)
     .then(_convertElasticSearchResult)

--- a/api/controllers/sources.js
+++ b/api/controllers/sources.js
@@ -15,4 +15,4 @@ function listSources(req, res) {
 
 module.exports = {
   list: listSources,
-}
+};

--- a/api/controllers/trials.js
+++ b/api/controllers/trials.js
@@ -6,7 +6,7 @@ const Record = require('../models/record');
 function getTrial(req, res) {
   const id = req.swagger.params.id.value;
 
-  return new Trial({ id: id }).fetch({ withRelated: Trial.relatedModels })
+  return new Trial({ id }).fetch({ withRelated: Trial.relatedModels })
     .then((trial) => {
       if (trial) {
         res.json(trial);
@@ -24,7 +24,7 @@ function getTrial(req, res) {
 function getRecord(req, res) {
   const id = req.swagger.params.id.value;
 
-  return new Record({ id: id }).fetch({ withRelated: Record.relatedModels })
+  return new Record({ id }).fetch({ withRelated: Record.relatedModels })
     .then((record) => {
       if (record) {
         res.json(record);
@@ -56,4 +56,4 @@ module.exports = {
   getTrial,
   getRecord,
   getRecords,
-}
+};

--- a/api/helpers/index.js
+++ b/api/helpers/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const urlFor = require('./url-for');
+
 module.exports = {
-  urlFor: require('./url-for'),
+  urlFor,
 };

--- a/api/helpers/url-for.js
+++ b/api/helpers/url-for.js
@@ -3,15 +3,15 @@
 const config = require('../../config');
 
 function urlFor(models) {
-  if (!Array.isArray(models)) {
-    models = [models];
-  }
-  const hasModelsWithoutId = (models.find((m) => m.id === undefined) !== undefined);
+  const modelsArray = (Array.isArray(models)) ? models : [models];
+  const hasModelsWithoutId = (modelsArray.find((m) => m.id === undefined) !== undefined);
 
   if (!hasModelsWithoutId) {
-    const path = models.map((model) => `${model.tableName}/${model.id}`);
+    const path = modelsArray.map((model) => `${model.tableName}/${model.id}`);
     return `${config.url}/v1/${path.join('/')}`;
   }
+
+  return undefined;
 }
 
 module.exports = urlFor;

--- a/api/models/base.js
+++ b/api/models/base.js
@@ -5,10 +5,10 @@ const uuid = require('node-uuid');
 const bookshelf = require('../../config').bookshelf;
 
 const BaseModel = bookshelf.Model.extend({
-  serialize: function (options) {
+  serialize(...args) {
     const attributes = Object.assign(
       {},
-      Object.getPrototypeOf(BaseModel.prototype).serialize.call(this, arguments)
+      Object.getPrototypeOf(BaseModel.prototype).serialize.call(this, args)
     );
 
     // FIXME: We don't want empty objects to be added to the resulting JSON.
@@ -23,20 +23,21 @@ const BaseModel = bookshelf.Model.extend({
 
     return _.omitBy(attributes, isNullOrEmptyPlainObject);
   },
-  toJSON: function () {
+  toJSON(...args) {
     // FIXME: Bookshelf's virtuals plugin adds the virtual attributes
     // regardless of their value. We can't change this behaviour on
     // `serialize()`, because the plugin overwrittes it, so we need to do it
     // here.
-    const json = Object.getPrototypeOf(BaseModel.prototype).toJSON.call(this, arguments);
+    const json = Object.getPrototypeOf(BaseModel.prototype).toJSON.call(this, args);
 
     return _.omitBy(json, _.isUndefined);
   },
-  initialize: function () {
+  initialize() {
     this.on('saving', this.addIdIfNeeded);
   },
   addIdIfNeeded: (model) => {
     if (!model.attributes.id) {
+        // eslint-disable-next-line no-param-reassign
       model.attributes.id = uuid.v1();
     }
   },

--- a/api/models/condition.js
+++ b/api/models/condition.js
@@ -12,11 +12,11 @@ const Condition = BaseModel.extend({
     'id',
     'name',
   ],
-  trials: function () {
+  trials() {
     return this.belongsToMany('Trial', 'trials_conditions');
   },
   virtuals: {
-    url: function () {
+    url() {
       return helpers.urlFor(this);
     },
   },

--- a/api/models/document.js
+++ b/api/models/document.js
@@ -9,6 +9,7 @@ const _ = require('lodash');
 const helpers = require('../helpers');
 const bookshelf = require('../../config').bookshelf;
 const BaseModel = require('./base');
+
 const relatedModels = [
   'file',
   'trials',
@@ -29,10 +30,10 @@ const Document = BaseModel.extend({
     'source_url',
     'fda_approval',
   ],
-  serialize: function (options) {
+  serialize(...args) {
     const attributes = Object.assign(
       {},
-      Object.getPrototypeOf(Document.prototype).serialize.call(this, arguments),
+      Object.getPrototypeOf(Document.prototype).serialize.call(this, args),
       {
         trials: this.related('trials').map((trial) => trial.toJSONSummary()),
       }
@@ -44,21 +45,21 @@ const Document = BaseModel.extend({
 
     return attributes;
   },
-  file: function () {
+  file() {
     return this.belongsTo('File');
   },
-  trials: function () {
+  trials() {
     return this.belongsToMany('Trial', 'trials_documents');
   },
-  source: function () {
+  source() {
     return this.belongsTo('Source');
   },
-  fda_approval: function () {
+  fda_approval() {
     return this.belongsTo('FDAApproval');
   },
-  toJSONSummary: function () {
+  toJSONSummary() {
     const isEmptyPlainObject = (value) => _.isPlainObject(value) && _.isEmpty(value);
-    const isNilOrEmptyPlainObject = (value) => _.isNil(value) || isEmptyPlainObject(value)
+    const isNilOrEmptyPlainObject = (value) => _.isNil(value) || isEmptyPlainObject(value);
     const attributes = Object.assign(
       this.toJSON(),
       {
@@ -73,7 +74,7 @@ const Document = BaseModel.extend({
 
     return _.omitBy(attributes, isNilOrEmptyPlainObject);
   },
-  toJSONWithoutPages: function () {
+  toJSONWithoutPages() {
     const attributes = this.toJSON();
 
     if (attributes.file !== undefined) {
@@ -83,7 +84,7 @@ const Document = BaseModel.extend({
     return attributes;
   },
   virtuals: {
-    url: function () {
+    url() {
       return helpers.urlFor(this);
     },
   },

--- a/api/models/fda_application.js
+++ b/api/models/fda_application.js
@@ -6,10 +6,11 @@ require('./organisation');
 const helpers = require('../helpers');
 const bookshelf = require('../../config').bookshelf;
 const BaseModel = require('./base');
+
 const relatedModels = [
   'fda_approvals',
   'organisation',
-]
+];
 
 const FDAApplication = BaseModel.extend({
   tableName: 'fda_applications',
@@ -20,25 +21,26 @@ const FDAApplication = BaseModel.extend({
     'fda_approvals',
     'organisation',
   ],
-  fda_approvals: function () {
+  fda_approvals() {
     return this.hasMany('FDAApproval');
   },
-  organisation: function () {
+  organisation() {
     return this.belongsTo('Organisation');
   },
   virtuals: {
-    url: function () {
+    url() {
       return helpers.urlFor(this);
     },
-    type: function () {
+    type() {
       const matches = this.id.match(/^[A-Z]+/i);
       if (matches) {
         return matches[0];
       }
+      return undefined;
     },
   },
 }, {
-  relatedModels
+  relatedModels,
 });
 
 module.exports = bookshelf.model('FDAApplication', FDAApplication);

--- a/api/models/fda_approval.js
+++ b/api/models/fda_approval.js
@@ -15,7 +15,7 @@ const FDAApproval = BaseModel.extend({
     'notes',
     'fda_application',
   ],
-  fda_application: function () {
+  fda_application() {
     return this.belongsTo('FDAApplication');
   },
 });

--- a/api/models/file.js
+++ b/api/models/file.js
@@ -12,10 +12,10 @@ const File = BaseModel.extend({
     'sha1',
     'pages',
   ],
-  serialize: function () {
+  serialize(...args) {
     const attributes = Object.assign(
       {},
-      Object.getPrototypeOf(File.prototype).serialize.call(this, arguments)
+      Object.getPrototypeOf(File.prototype).serialize.call(this, args)
     );
 
     if (attributes.pages) {
@@ -24,7 +24,7 @@ const File = BaseModel.extend({
 
     return attributes;
   },
-  toJSONSummary: function () {
+  toJSONSummary() {
     const attributes = this.toJSON();
 
     delete attributes.pages;

--- a/api/models/intervention.js
+++ b/api/models/intervention.js
@@ -13,11 +13,11 @@ const Intervention = BaseModel.extend({
     'name',
     'type',
   ],
-  trials: function () {
+  trials() {
     return this.belongsToMany('Trial', 'trials_interventions');
   },
   virtuals: {
-    url: function () {
+    url() {
       return helpers.urlFor(this);
     },
   },

--- a/api/models/location.js
+++ b/api/models/location.js
@@ -4,7 +4,6 @@ require('./trial');
 
 const bookshelf = require('../../config').bookshelf;
 const BaseModel = require('./base');
-const helpers = require('../helpers');
 
 const Location = BaseModel.extend({
   tableName: 'locations',
@@ -13,7 +12,7 @@ const Location = BaseModel.extend({
     'name',
     'type',
   ],
-  trials: function () {
+  trials() {
     return this.belongsToMany('Trial', 'trials_locations',
       'location_id', 'trial_id').withPivot(['role']);
   },

--- a/api/models/organisation.js
+++ b/api/models/organisation.js
@@ -12,12 +12,12 @@ const Organisation = BaseModel.extend({
     'id',
     'name',
   ],
-  trials: function () {
+  trials() {
     return this.belongsToMany('Trial', 'trials_organisations',
       'organisation_id', 'trial_id').withPivot(['role']);
   },
   virtuals: {
-    url: function () {
+    url() {
       return helpers.urlFor(this);
     },
   },

--- a/api/models/person.js
+++ b/api/models/person.js
@@ -12,12 +12,12 @@ const Person = BaseModel.extend({
     'id',
     'name',
   ],
-  trials: function () {
+  trials() {
     return this.belongsToMany('Trial', 'trials_persons',
       'person_id', 'trial_id').withPivot(['role']);
   },
   virtuals: {
-    url: function () {
+    url() {
       return helpers.urlFor(this);
     },
   },

--- a/api/models/publication.js
+++ b/api/models/publication.js
@@ -2,8 +2,8 @@
 
 const bookshelf = require('../../config').bookshelf;
 const BaseModel = require('./base');
-const Source = require('./source');
 const helpers = require('../helpers');
+require('./source');
 
 const relatedModels = [
   'source',
@@ -22,10 +22,10 @@ const Publication = BaseModel.extend({
     'updated_at',
     'authors',
   ],
-  source: function () {
+  source() {
     return this.belongsTo('Source');
   },
-  toJSONSummary: function () {
+  toJSONSummary() {
     const attributes = this.toJSON();
     const result = {
       id: attributes.id,
@@ -38,12 +38,12 @@ const Publication = BaseModel.extend({
     return result;
   },
   virtuals: {
-    url: function () {
+    url() {
       return helpers.urlFor(this);
     },
   },
 }, {
-  relatedModels
+  relatedModels,
 });
 
 module.exports = bookshelf.model('Publication', Publication);

--- a/api/models/record.js
+++ b/api/models/record.js
@@ -2,9 +2,10 @@
 
 const bookshelf = require('../../config').bookshelf;
 const BaseModel = require('./base');
-const Trial = require('./trial');
-const Source = require('./source');
 const helpers = require('../helpers');
+require('./trial');
+require('./source');
+
 const relatedModels = [
   'trial',
   'source',
@@ -33,13 +34,13 @@ const Record = BaseModel.extend({
     'created_at',
     'updated_at',
   ],
-  trial: function () {
+  trial() {
     return this.belongsTo('Trial');
   },
-  source: function () {
+  source() {
     return this.belongsTo('Source', 'source_id');
   },
-  toJSONSummary: function () {
+  toJSONSummary() {
     const attributes = this.toJSON();
     const result = {
       id: attributes.id,
@@ -64,12 +65,12 @@ const Record = BaseModel.extend({
     return result;
   },
   virtuals: {
-    url: function () {
+    url() {
       const fakeTrial = { id: this.attributes.trial_id, tableName: 'trials' };
       const fakeRecord = { id: this.id, tableName: 'records' };
       return helpers.urlFor([fakeTrial, fakeRecord]);
     },
-    trial_url: function () {
+    trial_url() {
       const fakeTrial = { id: this.attributes.trial_id, tableName: 'trials' };
       return helpers.urlFor(fakeTrial);
     },

--- a/api/models/risk_of_bias.js
+++ b/api/models/risk_of_bias.js
@@ -21,10 +21,10 @@ const RiskOfBias = BaseModel.extend({
     'updated_at',
     'source',
   ],
-  source: function () {
+  source() {
     return this.belongsTo('Source', 'source_id');
   },
-  risk_of_bias_criteria: function() {
+  risk_of_bias_criteria() {
     return this.belongsToMany('RiskOfBiasCriteria', 'risk_of_biases_risk_of_bias_criterias',
       'risk_of_bias_id', 'risk_of_bias_criteria_id').withPivot(['value']);
   },

--- a/api/models/risk_of_bias_criteria.js
+++ b/api/models/risk_of_bias_criteria.js
@@ -13,15 +13,15 @@ const RiskOfBiasCriteria = BaseModel.extend({
     'name',
     'value',
   ],
-  risk_of_bias: function() {
+  risk_of_bias() {
     return this.belongsToMany('RiskOfBias', 'risk_of_biases_risk_of_bias_criterias',
       'risk_of_bias_id', 'risk_of_bias_criteria_id').withPivot(['value']);
   },
   virtuals: {
-    value: function (options) {
+    value() {
       return this.pivot.attributes.value;
-    }
-  }
+    },
+  },
 });
 
 module.exports = bookshelf.model('RiskOfBiasCriteria', RiskOfBiasCriteria);

--- a/package.json
+++ b/package.json
@@ -53,16 +53,16 @@
     "supertest": "^1.0.0"
   },
   "scripts": {
-    "e2e": "mocha --grep e2e",
-    "test": "node ./node_modules/.bin/istanbul cover _mocha -- --grep e2e --invert",
+    "e2e": "mocha --harmony_rest_parameters --grep e2e",
+    "test": "node --harmony_rest_parameters ./node_modules/.bin/istanbul cover _mocha -- --grep e2e --invert",
     "posttest": "npm run lint",
-    "lint": "eslint *.js **/*.js",
+    "lint": "eslint .",
     "precoveralls": "npm test",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "migrate": "knex migrate:latest",
     "seed": "knex seed:run",
-    "start": "node --optimize_for_size --max_old_space_size=460 --gc_interval=100 server.js",
-    "dev": "nodemon server.js",
-    "reindex": "node --optimize_for_size --max_old_space_size=460 --gc_interval=100 ./tools/reindex.js"
+    "start": "node --harmony_rest_parameters --optimize_for_size --max_old_space_size=460 --gc_interval=100 server.js",
+    "dev": "nodemon --harmony_rest_parameters server.js",
+    "reindex": "node --harmony_rest_parameters --optimize_for_size --max_old_space_size=460 --gc_interval=100 ./tools/reindex.js"
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -2,6 +2,12 @@
 extends: ../.eslintrc
 env:
   mocha: true
+globals:
+  server: false
+  factory: false
+  config: false
+  clearDB: false
+  toJSON: false
 rules:
   import/no-extraneous-dependencies:
     - error

--- a/test/api/controllers/conditions.js
+++ b/test/api/controllers/conditions.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const Condition = require('../../../api/models/condition');
-
 describe('Conditions', () => {
   before(clearDB);
 
@@ -16,8 +14,8 @@ describe('Conditions', () => {
     ));
 
     it('returns the Condition', () => (
-      factory.create('condition').then((model) => {
-        return server.inject('/v1/conditions/' + model.attributes.id)
+      factory.create('condition').then((model) => (
+        server.inject(`/v1/conditions/${model.attributes.id}`)
           .then((response) => {
             response.statusCode.should.equal(200);
 
@@ -26,7 +24,7 @@ describe('Conditions', () => {
 
             result.should.deepEqual(expectedResult);
           })
-      })
+      ))
     ));
   });
 });

--- a/test/api/controllers/documents.js
+++ b/test/api/controllers/documents.js
@@ -1,3 +1,5 @@
+/* eslint-disable max-len */
+
 'use strict';
 
 const Document = require('../../../api/models/document');
@@ -8,19 +10,19 @@ describe('Document', () => {
   afterEach(clearDB);
 
   describe('GET /v1/documents/{id}', () => {
-    it('returns 404 if there\'s no document with the received ID', () => {
-      return server.inject('/v1/documents/00000000-0000-0000-0000-000000000000')
+    it('returns 404 if there\'s no document with the received ID', () => (
+      server.inject('/v1/documents/00000000-0000-0000-0000-000000000000')
         .then((response) => {
           response.statusCode.should.equal(404);
         })
-    });
+    ));
 
     it('returns the document', () => {
       let doc;
 
       return factory.create('document')
         .then((_doc) => new Document({ id: _doc.attributes.id }).fetch({ withRelated: Document.relatedModels }))
-        .then((_doc) => doc = _doc)
+        .then((_doc) => (doc = _doc))
         .then(() => server.inject(`/v1/documents/${doc.attributes.id}`))
         .then((response) => {
           response.statusCode.should.equal(200);
@@ -39,7 +41,7 @@ describe('Document', () => {
 
       return factory.create('documentWithFile')
         .then((_doc) => new Document({ id: _doc.attributes.id }).fetch({ withRelated: Document.relatedModels }))
-        .then((_doc) => doc = _doc)
+        .then((_doc) => (doc = _doc))
         .then(() => server.inject('/v1/documents'))
         .then((response) => {
           response.statusCode.should.equal(200);
@@ -47,26 +49,26 @@ describe('Document', () => {
           const expectedResult = {
             total_count: 1,
             items: [doc.toJSONSummary()],
-          }
+          };
           const result = JSON.parse(response.result);
           result.should.deepEqual(toJSON(expectedResult));
         });
     });
 
     it('returns empty items array when there are no more documents', () => (
-      factory.create('document').then((model) => {
-        return server.inject('/v1/documents?page=2')
+      factory.create('document').then(() => (
+        server.inject('/v1/documents?page=2')
           .then((response) => {
             response.statusCode.should.equal(200);
 
             const expectedResult = {
               total_count: 1,
               items: [],
-            }
+            };
             const result = JSON.parse(response.result);
             result.should.deepEqual(expectedResult);
           })
-      })
+      ))
     ));
   });
 });

--- a/test/api/controllers/fda_applications.js
+++ b/test/api/controllers/fda_applications.js
@@ -14,8 +14,8 @@ describe('FDAApplication', () => {
     ));
 
     it('returns the FDA application', () => (
-      factory.create('fda_application').then((model) => {
-        return server.inject(`/v1/fda_applications/${model.attributes.id}`)
+      factory.create('fda_application').then((model) => (
+        server.inject(`/v1/fda_applications/${model.attributes.id}`)
           .then((response) => {
             response.statusCode.should.equal(200);
 
@@ -24,41 +24,41 @@ describe('FDAApplication', () => {
 
             result.should.deepEqual(expectedResult);
           })
-      })
+      ))
     ));
   });
 
   describe('GET /v1/fda_applications', () => {
     it('returns the FDA applications in pages', () => (
-      factory.create('fda_application').then((model) => {
-        return server.inject('/v1/fda_applications')
+      factory.create('fda_application').then((model) => (
+        server.inject('/v1/fda_applications')
           .then((response) => {
             response.statusCode.should.equal(200);
 
             const expectedResult = {
               total_count: 1,
               items: [toJSON(model)],
-            }
+            };
             const result = JSON.parse(response.result);
             result.should.deepEqual(expectedResult);
           })
-      })
+      ))
     ));
 
     it('returns empty items array when there are no more results', () => (
-      factory.create('fda_application').then((model) => {
-        return server.inject('/v1/fda_applications?page=2')
+      factory.create('fda_application').then(() => (
+        server.inject('/v1/fda_applications?page=2')
           .then((response) => {
             response.statusCode.should.equal(200);
 
             const expectedResult = {
               total_count: 1,
               items: [],
-            }
+            };
             const result = JSON.parse(response.result);
             result.should.deepEqual(expectedResult);
           })
-      })
+      ))
     ));
   });
 });

--- a/test/api/controllers/interventions.js
+++ b/test/api/controllers/interventions.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const Intervention = require('../../../api/models/intervention');
-
 describe('Interventions', () => {
   before(clearDB);
 
@@ -16,8 +14,8 @@ describe('Interventions', () => {
     ));
 
     it('returns the Intervention', () => (
-      factory.create('intervention').then((model) => {
-        return server.inject('/v1/interventions/' + model.attributes.id)
+      factory.create('intervention').then((model) => (
+        server.inject(`/v1/interventions/${model.attributes.id}`)
           .then((response) => {
             response.statusCode.should.equal(200);
 
@@ -26,7 +24,7 @@ describe('Interventions', () => {
 
             result.should.deepEqual(expectedResult);
           })
-      })
+      ))
     ));
   });
 });

--- a/test/api/controllers/organisations.js
+++ b/test/api/controllers/organisations.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const Organisation = require('../../../api/models/organisation');
-
 describe('Organisations', () => {
   before(clearDB);
 
@@ -16,8 +14,8 @@ describe('Organisations', () => {
     ));
 
     it('returns the Organisation', () => (
-      factory.create('organisation').then((model) => {
-        return server.inject('/v1/organisations/' + model.attributes.id)
+      factory.create('organisation').then((model) => (
+        server.inject(`/v1/organisations/${model.attributes.id}`)
           .then((response) => {
             response.statusCode.should.equal(200);
 
@@ -26,7 +24,7 @@ describe('Organisations', () => {
 
             result.should.deepEqual(expectedResult);
           })
-      })
+      ))
     ));
   });
 });

--- a/test/api/controllers/persons.js
+++ b/test/api/controllers/persons.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const Person = require('../../../api/models/person');
-
 describe('Persons', () => {
   before(clearDB);
 
@@ -16,8 +14,8 @@ describe('Persons', () => {
     ));
 
     it('returns the Person', () => (
-      factory.create('person').then((model) => {
-        return server.inject('/v1/persons/' + model.attributes.id)
+      factory.create('person').then((model) => (
+        server.inject(`/v1/persons/${model.attributes.id}`)
           .then((response) => {
             response.statusCode.should.equal(200);
 
@@ -26,7 +24,7 @@ describe('Persons', () => {
 
             result.should.deepEqual(expectedResult);
           })
-      })
+      ))
     ));
   });
 });

--- a/test/api/controllers/publications.js
+++ b/test/api/controllers/publications.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const Publication = require('../../../api/models/publication');
-
 describe('Publication', () => {
   before(clearDB);
 
@@ -19,7 +17,7 @@ describe('Publication', () => {
       let publication;
 
       return factory.create('publication')
-        .then((_publication) => publication = _publication)
+        .then((_publication) => (publication = _publication))
         .then(() => server.inject(`/v1/publications/${publication.attributes.id}`))
         .then((response) => {
           response.statusCode.should.equal(200);

--- a/test/api/controllers/search.js
+++ b/test/api/controllers/search.js
@@ -4,14 +4,21 @@ const should = require('should');
 const sinon = require('sinon');
 const elasticsearch = require('../../../config').elasticsearch;
 
+const EMPTY_ES_RESPONSE = {
+  hits: {
+    total: 0,
+    hits: [],
+  },
+};
+
 
 describe('Search', () => {
-  before(clearDB)
+  before(clearDB);
 
-  afterEach(clearDB)
+  afterEach(clearDB);
 
   beforeEach(() => {
-    sinon.stub(elasticsearch, 'search')
+    sinon.stub(elasticsearch, 'search');
   });
 
   afterEach(() => {
@@ -85,7 +92,7 @@ describe('Search', () => {
             total_count: 0,
             items: [],
           });
-        })
+        });
     });
 
     it('returns the found entities adding the page inner_hits page to doc.file.pages', () => {
@@ -217,7 +224,7 @@ function basicSearchTests(url, factoryName) {
             total_count: 0,
             items: [],
           });
-        })
+        });
     });
 
     it('returns the found entities', () => {
@@ -239,9 +246,9 @@ function basicSearchTests(url, factoryName) {
           response.statusCode.should.equal(200);
           JSON.parse(response.result).should.deepEqual({
             total_count: items.length,
-            items: items,
+            items,
           });
-        })
+        });
     });
 
     it('defines the default operator as AND', () => {
@@ -284,33 +291,33 @@ function paginationTests(url) {
       elasticsearch.search.returns(Promise.resolve(EMPTY_ES_RESPONSE));
     });
 
-    it('defaults to first page and 20 items per page', () => {
-      return server.inject(url)
+    it('defaults to first page and 20 items per page', () => (
+      server.inject(url)
         .then(() => {
           elasticsearch.search.calledWithMatch({ from: 0, size: 20 }).should.be.true();
-        });
-    });
+        })
+    ));
 
-    it('allows getting other pages', () => {
-      return server.inject(`${url}?page=3&per_page=20`)
+    it('allows getting other pages', () => (
+      server.inject(`${url}?page=3&per_page=20`)
         .then(() => {
           elasticsearch.search.calledWithMatch({ from: 40, size: 20 }).should.be.true();
-        });
-    });
+        })
+    ));
 
-    it('allows changing number of items per page', () => {
-      return server.inject(`${url}?per_page=33`)
+    it('allows changing number of items per page', () => (
+      server.inject(`${url}?per_page=33`)
         .then(() => {
           elasticsearch.search.calledWithMatch({ from: 0, size: 33 }).should.be.true();
-        });
-    });
+        })
+    ));
 
     it('total_count contains the number of items in total, not per page', () => {
       const esResult = {
         hits: {
           total: 51,
-          hits: []
-        }
+          hits: [],
+        },
       };
 
       elasticsearch.search.returns(Promise.resolve(esResult));
@@ -323,54 +330,54 @@ function paginationTests(url) {
         });
     });
 
-    it('validates that page is greater than 1', () => {
+    it('validates that page is greater than 1', () => (
       // FIXME: Should return error HTTP status code
-      return server.inject(`${url}?page=0`)
+      server.inject(`${url}?page=0`)
         .then((response) => {
           const result = JSON.parse(response.result);
 
           should(result.failedValidation).be.true();
           should(result.code).equal('MINIMUM');
           should(result.paramName).equal('page');
-        });
-    });
+        })
+    ));
 
-    it('validates that page is smaller than 100', () => {
+    it('validates that page is smaller than 100', () => (
       // FIXME: Should return error HTTP status code
-      return server.inject(`${url}?page=101`)
+      server.inject(`${url}?page=101`)
         .then((response) => {
           const result = JSON.parse(response.result);
 
           should(result.failedValidation).be.true();
           should(result.code).equal('MAXIMUM');
           should(result.paramName).equal('page');
-        });
-    });
+        })
+    ));
 
-    it('validates that items per page is greater than 10', () => {
+    it('validates that items per page is greater than 10', () => (
       // FIXME: Should return error HTTP status code
-      return server.inject(`${url}?per_page=9`)
+      server.inject(`${url}?per_page=9`)
         .then((response) => {
           const result = JSON.parse(response.result);
 
           should(result.failedValidation).be.true();
           should(result.code).equal('MINIMUM');
           should(result.paramName).equal('per_page');
-        });
-    });
+        })
+    ));
 
-    it('validates that items per page is smaller than 100', () => {
+    it('validates that items per page is smaller than 100', () => (
       // FIXME: Should return error HTTP status code
-      return server.inject(`${url}?per_page=101`)
+      server.inject(`${url}?per_page=101`)
         .then((response) => {
           const result = JSON.parse(response.result);
 
           should(result.failedValidation).be.true();
           should(result.code).equal('MAXIMUM');
           should(result.paramName).equal('per_page');
-        });
-    });
-  }
+        })
+    ));
+  };
 }
 
 function autocompleteTests(url, factoryName) {
@@ -406,11 +413,3 @@ function autocompleteTests(url, factoryName) {
     });
   };
 }
-
-
-const EMPTY_ES_RESPONSE = {
-  hits: {
-    total: 0,
-    hits: [],
-  },
-};

--- a/test/api/controllers/sources.js
+++ b/test/api/controllers/sources.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const Source = require('../../../api/models/source');
-
 describe('Sources', () => {
   before(clearDB);
 
@@ -9,8 +7,8 @@ describe('Sources', () => {
 
   describe('GET /v1/sources', () => {
     it('returns all the sources', () => (
-      factory.createMany('source', 2).then((models) => {
-        return server.inject('/v1/sources')
+      factory.createMany('source', 2).then((models) => (
+        server.inject('/v1/sources')
           .then((response) => {
             response.statusCode.should.equal(200);
 
@@ -19,7 +17,7 @@ describe('Sources', () => {
 
             result.should.deepEqual(expectedResult);
           })
-      })
+      ))
     ));
   });
 });

--- a/test/api/controllers/trials.js
+++ b/test/api/controllers/trials.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const should = require('should');
-const Trial = require('../../../api/models/trial');
 const Record = require('../../../api/models/record');
 
 describe('Trials', () => {
@@ -20,7 +19,7 @@ describe('Trials', () => {
     it('returns the Trial', () => (
       factory.create('trialWithRelated')
         .then((trial) => (
-          server.inject('/v1/trials/'+trial.attributes.id)
+          server.inject(`/v1/trials/${trial.attributes.id}`)
             .then((response) => {
               response.statusCode.should.equal(200);
 
@@ -46,7 +45,7 @@ describe('Trials', () => {
     it('returns the records', () => (
       factory.create('record')
         .then((record) => (
-          server.inject('/v1/trials/'+record.attributes.trial_id+'/records/'+record.attributes.id)
+          server.inject(`/v1/trials/${record.attributes.trial_id}/records/${record.attributes.id}`)
             .then((response) => {
               response.statusCode.should.equal(200);
 
@@ -63,15 +62,15 @@ describe('Trials', () => {
 
   describe('GET /v1/trials/{id}/records', () => {
     it('returns an array with all trial\'s records', () => {
-      let trial_id;
+      let trialId;
       let records;
 
       return factory.create('trial')
-        .then((trial) => trial_id = trial.attributes.id)
-        .then(() => factory.createMany('record', { trial_id }, 2))
-        .then(() => Record.query({ where: { trial_id } }).fetchAll({ withRelated: ['source'] }))
-        .then((_records) => records = _records)
-        .then(() => server.inject(`/v1/trials/${trial_id}/records`))
+        .then((trial) => (trialId = trial.attributes.id))
+        .then(() => factory.createMany('record', { trial_id: trialId }, 2))
+        .then(() => Record.query({ where: { trial_id: trialId } }).fetchAll({ withRelated: ['source'] }))
+        .then((_records) => (records = _records))
+        .then(() => server.inject(`/v1/trials/${trialId}/records`))
         .then((response) => {
           response.statusCode.should.equal(200);
 
@@ -80,14 +79,14 @@ describe('Trials', () => {
         });
     });
 
-    it('returns empty array if the trial has no records', () => {
-      return server.inject('/v1/trials/00000000-0000-0000-0000-000000000000/records')
+    it('returns empty array if the trial has no records', () => (
+      server.inject('/v1/trials/00000000-0000-0000-0000-000000000000/records')
         .then((response) => {
           response.statusCode.should.equal(200);
 
           const result = JSON.parse(response.result);
           should(result).deepEqual([]);
-        });
-    });
+        })
+    ));
   });
 });

--- a/test/api/models/condition.js
+++ b/test/api/models/condition.js
@@ -21,14 +21,14 @@ describe('Condition', () => {
         }).then((condition) => {
           const trialsIds = condition.related('trials').models.map((trial) => trial.id);
           should(trialsIds).containEql(trialId);
-        })
-    })
+        });
+    });
   });
 
   describe('url', () => {
-    it('returns the url', () => {
-      return factory.build('condition')
-        .then((condition) => should(condition.toJSON().url).eql(helpers.urlFor(condition)));
-    });
+    it('returns the url', () => (
+      factory.build('condition')
+        .then((condition) => should(condition.toJSON().url).eql(helpers.urlFor(condition)))
+    ));
   });
 });

--- a/test/api/models/document.js
+++ b/test/api/models/document.js
@@ -3,7 +3,6 @@
 const _ = require('lodash');
 const should = require('should');
 const helpers = require('../../../api/helpers');
-const Document = require('../../../api/models/document');
 
 describe('Document', () => {
   before(clearDB);
@@ -11,8 +10,8 @@ describe('Document', () => {
   afterEach(clearDB);
 
   describe('toJSONSummary', () => {
-    it('returns simplified document representation', () => {
-      return factory.create('documentWithRelated')
+    it('returns simplified document representation', () => (
+      factory.create('documentWithRelated')
         .then((doc) => {
           const attributes = doc.toJSON();
           const expected = {
@@ -25,14 +24,14 @@ describe('Document', () => {
             file: doc.related('file').toJSONSummary(),
             trials: doc.related('trials').map((t) => t.toJSONSummary()),
             fda_approval: doc.related('fda_approval').toJSON(),
-          }
+          };
 
-          doc.toJSONSummary().should.deepEqual(expected)
-        });
-    });
+          doc.toJSONSummary().should.deepEqual(expected);
+        })
+    ));
 
-    it('doesn\'t return null or undefined values for documents without files', () => {
-      return factory.create('document', { source_id: null, fda_approval_id: null, file_id: null })
+    it('doesn\'t return null or undefined values for documents without files', () => (
+      factory.create('document', { source_id: null, fda_approval_id: null, file_id: null })
         .then((doc) => {
           const jsonSummary = doc.toJSONSummary();
           const values = _.values(jsonSummary);
@@ -40,10 +39,10 @@ describe('Document', () => {
           should(values).not.containEql(null);
           should(values).not.containEql(undefined);
         })
-    })
+    ));
 
-    it('doesn\'t return null or undefined values for documents with files', () => {
-      return factory.create('documentWithFile', { source_id: null, fda_approval_id: null, source_url: null })
+    it('doesn\'t return null or undefined values for documents with files', () => (
+      factory.create('documentWithFile', { source_id: null, fda_approval_id: null, source_url: null })
         .then((doc) => {
           const jsonSummary = doc.toJSONSummary();
           const values = _.values(jsonSummary);
@@ -51,12 +50,12 @@ describe('Document', () => {
           should(values).not.containEql(null);
           should(values).not.containEql(undefined);
         })
-    })
+    ));
   });
 
   describe('toJSONWithoutPages', () => {
-    it('returns JSON removing files.pages', () => {
-      return factory.create('documentWithRelated')
+    it('returns JSON removing files.pages', () => (
+      factory.create('documentWithRelated')
         .then((doc) => {
           const json = doc.toJSON();
           const jsonWithoutPages = doc.toJSONWithoutPages();
@@ -67,15 +66,15 @@ describe('Document', () => {
           delete json.file.pages;
 
           should(jsonWithoutPages).deepEqual(json);
-        });
-    });
+        })
+    ));
 
-    it('returns same as toJSON() if document has no file', () => {
-      return factory.create('document', { file_id: null })
+    it('returns same as toJSON() if document has no file', () => (
+      factory.create('document', { file_id: null })
         .then((doc) => {
           should(doc.toJSONWithoutPages()).deepEqual(doc.toJSON());
         })
-    });
+    ));
   });
 
   describe('virtuals', () => {
@@ -89,21 +88,21 @@ describe('Document', () => {
 
   describe('serialize', () => {
     describe('trial', () => {
-      it('is the trial\'s JSON summary', () => {
-        return factory.create('documentWithRelated')
+      it('is the trial\'s JSON summary', () => (
+        factory.create('documentWithRelated')
           .then((doc) => {
             const trialsJSONSummary = doc.related('trials').map((trial) => trial.toJSONSummary());
             should(doc.toJSON().trials).deepEqual(trialsJSONSummary);
-          });
-      });
+          })
+      ));
     });
 
-    it('returns source_url as file.source_url if it has a file', () => {
-      return factory.create('documentWithRelated')
+    it('returns source_url as file.source_url if it has a file', () => (
+      factory.create('documentWithRelated')
         .then((doc) => {
           const fileSourceUrl = doc.related('file').attributes.source_url;
           should(doc.toJSON().source_url).eql(fileSourceUrl);
-        });
-    });
+        })
+    ));
   });
 });

--- a/test/api/models/fda_application.js
+++ b/test/api/models/fda_application.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const should = require('should');
-const Document = require('../../../api/models/document');
 
 describe('FDAApplication', () => {
   before(clearDB);
@@ -11,13 +10,13 @@ describe('FDAApplication', () => {
   describe('virtuals', () => {
     describe('type', () => {
       it('extracts the type from the ID', () => (
-        factory.build('fda_application', {id: 'ANDA000000'})
+        factory.build('fda_application', { id: 'ANDA000000' })
           .then((fdaApproval) => should(fdaApproval.toJSON().type).equal('ANDA'))
       ));
 
       it('is undefined when could not extract it from the ID', () => {
-        factory.build('fda_application', {id: '0'})
-          .then((fdaApproval) => should(fdaApproval.toJSON().type).be.undefined())
+        factory.build('fda_application', { id: '0' })
+          .then((fdaApproval) => should(fdaApproval.toJSON().type).be.undefined());
       });
     });
   });

--- a/test/api/models/file.js
+++ b/test/api/models/file.js
@@ -9,39 +9,39 @@ describe('File', () => {
   afterEach(clearDB);
 
   describe('toJSONSummary', () => {
-    it('returns simplified file representation', () => {
-      return factory.create('file')
+    it('returns simplified file representation', () => (
+      factory.create('file')
         .then((file) => file.toJSONSummary().should.deepEqual({
           id: file.attributes.id,
           sha1: file.attributes.sha1,
           source_url: file.attributes.source_url,
           documentcloud_id: file.attributes.documentcloud_id,
-        }));
-    });
+        }))
+    ));
 
     it('is an empty object if file is empty', () => {
       const file = new File();
 
       should(file.toJSONSummary()).deepEqual({});
-    })
+    });
   });
 
   describe('toJSON', () => {
-    it('returns the pages as object with "num" and "text" fields', () => {
-      return factory.create('file', { pages: ['foo', 'bar'] })
+    it('returns the pages as object with "num" and "text" fields', () => (
+      factory.create('file', { pages: ['foo', 'bar'] })
         .then((file) => {
           file.toJSON().pages.should.deepEqual([
             { num: 1, text: 'foo' },
             { num: 2, text: 'bar' },
           ]);
-        });
-    });
+        })
+    ));
 
-    it('returns the pages undefined when there are no pages', () => {
-      return factory.create('file', { pages: null })
+    it('returns the pages undefined when there are no pages', () => (
+      factory.create('file', { pages: null })
         .then((file) => {
           should(file.toJSON().pages).be.undefined();
-        });
-    });
+        })
+    ));
   });
 });

--- a/test/api/models/intervention.js
+++ b/test/api/models/intervention.js
@@ -21,14 +21,14 @@ describe('Intervention', () => {
         }).then((intervention) => {
           const trialsIds = intervention.related('trials').models.map((trial) => trial.id);
           should(trialsIds).containEql(trialId);
-        })
-    })
+        });
+    });
   });
 
   describe('url', () => {
-    it('returns the url', () => {
-      return factory.build('intervention')
-        .then((intervention) => should(intervention.toJSON().url).eql(helpers.urlFor(intervention)));
-    });
+    it('returns the url', () => (
+      factory.build('intervention')
+        .then((interven) => should(interven.toJSON().url).eql(helpers.urlFor(interven)))
+    ));
   });
 });

--- a/test/api/models/location.js
+++ b/test/api/models/location.js
@@ -1,13 +1,12 @@
 'use strict';
 
 const should = require('should');
-const helpers = require('../../../api/helpers');
 const Location = require('../../../api/models/location');
 
 describe('Location', () => {
-  before(clearDB)
+  before(clearDB);
 
-  afterEach(clearDB)
+  afterEach(clearDB);
 
   describe('trials', () => {
     it('returns trials related to the location', () => {
@@ -21,7 +20,7 @@ describe('Location', () => {
         }).then((loc) => {
           const trialsIds = loc.related('trials').models.map((trial) => trial.id);
           should(trialsIds).containEql(trialId);
-        })
-    })
+        });
+    });
   });
 });

--- a/test/api/models/organisation.js
+++ b/test/api/models/organisation.js
@@ -5,9 +5,9 @@ const helpers = require('../../../api/helpers');
 const Organisation = require('../../../api/models/organisation');
 
 describe('Organisation', () => {
-  before(clearDB)
+  before(clearDB);
 
-  afterEach(clearDB)
+  afterEach(clearDB);
 
   describe('trials', () => {
     it('returns trials related to the organisation', () => {
@@ -21,14 +21,14 @@ describe('Organisation', () => {
         }).then((organisation) => {
           const trialsIds = organisation.related('trials').models.map((trial) => trial.id);
           should(trialsIds).containEql(trialId);
-        })
-    })
+        });
+    });
   });
 
   describe('url', () => {
-    it('returns the url', () => {
-      return factory.build('organisation')
-        .then((organisation) => should(organisation.toJSON().url).eql(helpers.urlFor(organisation)));
-    });
+    it('returns the url', () => (
+      factory.build('organisation')
+        .then((org) => should(org.toJSON().url).eql(helpers.urlFor(org)))
+    ));
   });
 });

--- a/test/api/models/person.js
+++ b/test/api/models/person.js
@@ -5,9 +5,9 @@ const helpers = require('../../../api/helpers');
 const Person = require('../../../api/models/person');
 
 describe('Person', () => {
-  before(clearDB)
+  before(clearDB);
 
-  afterEach(clearDB)
+  afterEach(clearDB);
 
   describe('trials', () => {
     it('returns trials related to the person', () => {
@@ -21,14 +21,14 @@ describe('Person', () => {
         }).then((person) => {
           const trialsIds = person.related('trials').models.map((trial) => trial.id);
           should(trialsIds).containEql(trialId);
-        })
-    })
+        });
+    });
   });
 
   describe('url', () => {
-    it('returns the url', () => {
-      return factory.build('person')
-        .then((person) => should(person.toJSON().url).eql(helpers.urlFor(person)));
-    });
+    it('returns the url', () => (
+      factory.build('person')
+        .then((person) => should(person.toJSON().url).eql(helpers.urlFor(person)))
+    ));
   });
 });

--- a/test/api/models/publication.js
+++ b/test/api/models/publication.js
@@ -13,10 +13,10 @@ describe('Publication', () => {
     should(Publication.relatedModels).deepEqual([
       'source',
     ]);
-  })
+  });
 
-  it('#toJSONSummary returns simplified record representation', () => {
-    return factory.create('publication')
+  it('#toJSONSummary returns simplified record representation', () => (
+    factory.create('publication')
       .then((publication) => {
         publication.toJSONSummary().should.deepEqual({
           id: publication.attributes.id,
@@ -25,13 +25,13 @@ describe('Publication', () => {
           source_id: publication.attributes.source_id,
           source_url: publication.attributes.source_url,
         });
-      });
-  });
+      })
+  ));
 
   describe('url', () => {
-    it('returns the url', () => {
-      return factory.build('publication')
-        .then((publication) => should(publication.toJSON().url).eql(helpers.urlFor(publication)));
-    });
+    it('returns the url', () => (
+      factory.build('publication')
+        .then((publication) => should(publication.toJSON().url).eql(helpers.urlFor(publication)))
+    ));
   });
 });

--- a/test/api/models/record.js
+++ b/test/api/models/record.js
@@ -14,10 +14,10 @@ describe('Record', () => {
       'trial',
       'source',
     ]);
-  })
+  });
 
-  it('defines url and trial_url', () => {
-    return factory.create('record')
+  it('defines url and trial_url', () => (
+    factory.create('record')
       .then((record) => {
         const trial = record.related('trial');
         const fakeRecord = { id: record.id, tableName: 'records' };
@@ -26,11 +26,11 @@ describe('Record', () => {
           url: helpers.urlFor([trial, fakeRecord]),
           trial_url: helpers.urlFor(trial),
         });
-      });
-  });
+      })
+  ));
 
-  it('#toJSONSummary returns simplified record representation', () => {
-    return factory.create('record').then((record) => {
+  it('#toJSONSummary returns simplified record representation', () => (
+    factory.create('record').then((record) => {
       const recordJSON = record.toJSON();
 
       record.toJSONSummary().should.deepEqual({
@@ -42,6 +42,6 @@ describe('Record', () => {
         updated_at: recordJSON.updated_at,
         last_verification_date: recordJSON.last_verification_date,
       });
-    });
-  });
+    })
+  ));
 });

--- a/test/api/models/trial.js
+++ b/test/api/models/trial.js
@@ -3,13 +3,11 @@
 const should = require('should');
 const _ = require('lodash');
 const Trial = require('../../../api/models/trial');
-const Record = require('../../../api/models/record');
-const Location = require('../../../api/models/location');
 
 describe('Trial', () => {
-  before(clearDB)
+  before(clearDB);
 
-  afterEach(clearDB)
+  afterEach(clearDB);
 
   it('exists', () => {
     should.exist(Trial);
@@ -43,12 +41,12 @@ describe('Trial', () => {
     });
 
     it('adds the locations and its metadata from relationship into the resulting JSON', () => {
-      let trial_id;
+      let trialId;
       let loc;
 
       return factory.create('trial')
         .then((trial) => {
-          trial_id = trial.id;
+          trialId = trial.id;
 
           return factory.create('location').then((_loc) => {
             loc = _loc;
@@ -57,9 +55,9 @@ describe('Trial', () => {
               role: 'recruitment_countries',
             });
           });
-        }).then((trial) => {
-          return new Trial({ id: trial_id }).fetch({ withRelated: 'locations' })
-        }).then((trial) => {
+        })
+        .then(() => new Trial({ id: trialId }).fetch({ withRelated: 'locations' }))
+        .then((trial) => {
           should(toJSON(trial).locations).deepEqual([
             Object.assign({ role: 'recruitment_countries' }, toJSON(loc)),
           ]);
@@ -69,16 +67,16 @@ describe('Trial', () => {
 
   describe('interventions', () => {
     it('is an empty array if there\'re none', () => {
-      should(toJSON(new Trial).interventions).deepEqual([]);
+      should(toJSON(new Trial()).interventions).deepEqual([]);
     });
 
     it('adds the interventions and its metadata from relationship into the resulting JSON', () => {
-      let trial_id;
+      let trialId;
       let intervention;
 
       return factory.create('trial')
         .then((trial) => {
-          trial_id = trial.id;
+          trialId = trial.id;
 
           return factory.create('intervention').then((_intervention) => {
             intervention = _intervention;
@@ -87,9 +85,9 @@ describe('Trial', () => {
               intervention_id: intervention.id,
             });
           });
-        }).then((trial) => {
-          return new Trial({ id: trial_id }).fetch({ withRelated: 'interventions' })
-        }).then((trial) => {
+        })
+        .then(() => new Trial({ id: trialId }).fetch({ withRelated: 'interventions' }))
+        .then((trial) => {
           should(toJSON(trial).interventions).deepEqual([
             toJSON(intervention),
           ]);
@@ -103,12 +101,12 @@ describe('Trial', () => {
     });
 
     it('adds the conditions and its metadata from relationship into the resulting JSON', () => {
-      let trial_id;
+      let trialId;
       let condition;
 
       return factory.create('trial')
         .then((trial) => {
-          trial_id = trial.id;
+          trialId = trial.id;
 
           return factory.create('condition').then((_condition) => {
             condition = _condition;
@@ -117,9 +115,9 @@ describe('Trial', () => {
               condition_id: condition.id,
             });
           });
-        }).then((trial) => {
-          return new Trial({ id: trial_id }).fetch({ withRelated: 'conditions' })
-        }).then((trial) => {
+        })
+        .then(() => new Trial({ id: trialId }).fetch({ withRelated: 'conditions' }))
+        .then((trial) => {
           should(toJSON(trial).conditions).deepEqual([
             toJSON(condition),
           ]);
@@ -133,12 +131,12 @@ describe('Trial', () => {
     });
 
     it('adds the persons and its metadata from relationship into the resulting JSON', () => {
-      let trial_id;
+      let trialId;
       let person;
 
       return factory.create('trial')
         .then((trial) => {
-          trial_id = trial.id;
+          trialId = trial.id;
 
           return factory.create('person').then((_person) => {
             person = _person;
@@ -148,9 +146,9 @@ describe('Trial', () => {
               role: 'other',
             });
           });
-        }).then((trial) => {
-          return new Trial({ id: trial_id }).fetch({ withRelated: 'persons' })
-        }).then((trial) => {
+        })
+        .then(() => new Trial({ id: trialId }).fetch({ withRelated: 'persons' }))
+        .then((trial) => {
           should(toJSON(trial).persons).deepEqual([
             Object.assign({ role: 'other' }, toJSON(person)),
           ]);
@@ -164,12 +162,12 @@ describe('Trial', () => {
     });
 
     it('adds the organisations and its metadata from relationship into the resulting JSON', () => {
-      let trial_id;
+      let trialId;
       let organisation;
 
       return factory.create('trial')
         .then((trial) => {
-          trial_id = trial.id;
+          trialId = trial.id;
 
           return factory.create('organisation').then((_organisation) => {
             organisation = _organisation;
@@ -179,10 +177,9 @@ describe('Trial', () => {
               role: 'other',
             });
           });
-        }).then((trial) => {
-          return new Trial({ id: trial_id }).fetch({ withRelated: 'organisations' })
-        }).then((trial) => {
-
+        })
+        .then(() => new Trial({ id: trialId }).fetch({ withRelated: 'organisations' }))
+        .then((trial) => {
           should(toJSON(trial).organisations).deepEqual([
             Object.assign({ role: 'other' }, toJSON(organisation)),
           ]);
@@ -195,20 +192,16 @@ describe('Trial', () => {
       should(toJSON(new Trial()).records).deepEqual([]);
     });
 
-    it('adds the records and their sources into the resulting JSON', () => {
-      return factory.create('record')
-        .then((record) => {
-          const source = record.related('source');
-
-          return new Trial({ id: record.attributes.trial_id })
-            .fetch({ withRelated: ['records', 'records.source'] })
-            .then((trial) => {
-              should(toJSON(trial).records).deepEqual([
-                toJSON(record.toJSONSummary()),
-              ]);
-            });
-        });
-    });
+    it('adds the records and their sources into the resulting JSON', () => (
+      factory.create('record')
+        .then((record) => (
+          new Trial({ id: record.attributes.trial_id })
+            .fetch({ withRelated: ['records', 'records.source'] }))
+            .then((trial) => should(toJSON(trial).records).deepEqual([
+              toJSON(record.toJSONSummary()),
+            ]))
+        )
+    ));
   });
 
   describe('risks_of_bias', () => {
@@ -216,20 +209,19 @@ describe('Trial', () => {
       should(toJSON(new Trial()).risks_of_bias).deepEqual([]);
     });
 
-    it('adds the risks of bias and their criteria into the resulting JSON', () => {
-      return factory.create('risk_of_bias')
+    it('adds the risks of bias and their criteria into the resulting JSON', () => (
+      factory.create('risk_of_bias')
         .then((rob) => {
-          const criteria = rob.related('risk_of_bias_criteria');
+          // Trigger fetching of RoB Criteria
+          rob.related('risk_of_bias_criteria');
 
           return new Trial({ id: rob.attributes.trial_id })
             .fetch({ withRelated: ['risks_of_bias', 'risks_of_bias.risk_of_bias_criteria'] })
-            .then((trial) => {
-              should(toJSON(trial).risks_of_bias).deepEqual([
-                toJSON(rob.toJSON()),
-              ]);
-            });
-        });
-    });
+            .then((trial) => should(toJSON(trial).risks_of_bias).deepEqual([
+              toJSON(rob.toJSON()),
+            ]));
+        })
+    ));
   });
 
   describe('documents', () => {
@@ -238,12 +230,12 @@ describe('Trial', () => {
     });
 
     it('adds the documents into the resulting JSON', () => {
-      let trial_id;
+      let trialId;
       let doc;
 
       return factory.create('trial')
         .then((trial) => {
-          trial_id = trial.id;
+          trialId = trial.id;
 
           return factory.create('document').then((_doc) => {
             doc = _doc;
@@ -252,9 +244,9 @@ describe('Trial', () => {
               document_id: doc.id,
             });
           });
-        }).then((trial) => {
-          return new Trial({ id: trial_id }).fetch({ withRelated: 'documents' })
-        }).then((trial) => {
+        })
+        .then(() => new Trial({ id: trialId }).fetch({ withRelated: 'documents' }))
+        .then((trial) => {
           should(toJSON(trial).documents).deepEqual([
             doc.toJSONSummary(),
           ]);
@@ -264,8 +256,8 @@ describe('Trial', () => {
 
   describe('virtuals', () => {
     describe('sources', () => {
-      it('returns the publications sources', () => {
-        return factory.create('trialWithRelated')
+      it('returns the publications sources', () => (
+        factory.create('trialWithRelated')
           .then((trial) => {
             const publications = trial.related('publications');
             const publicationsSourcesIds = publications.map((pub) => pub.attributes.source_id);
@@ -273,10 +265,10 @@ describe('Trial', () => {
 
             should(sources).have.keys(publicationsSourcesIds);
           })
-      });
+      ));
 
-      it('returns the documents sources', () => {
-        return factory.create('trialWithRelated')
+      it('returns the documents sources', () => (
+        factory.create('trialWithRelated')
           .then((trial) => {
             const documents = trial.related('documents');
             const documentsSourcesIds = documents.map((doc) => doc.attributes.source_id);
@@ -284,10 +276,10 @@ describe('Trial', () => {
 
             should(sources).have.keys(documentsSourcesIds);
           })
-      });
+      ));
 
-      it('returns the records sources', () => {
-        return factory.create('trialWithRecord')
+      it('returns the records sources', () => (
+        factory.create('trialWithRecord')
           .then((trial) => {
             const records = trial.related('records');
             const recordsSourcesIds = records.map((rec) => rec.attributes.source_id);
@@ -295,52 +287,52 @@ describe('Trial', () => {
 
             should(sources).have.keys(recordsSourcesIds);
           })
-      });
+      ));
 
-      it('ignores documents without sources', () => {
-        return factory.create('trial')
+      it('ignores documents without sources', () => (
+        factory.create('trial')
           .then((trial) => factory.create('document', { source_id: null })
             .then((doc) => trial.documents().attach({
               document_id: doc.id,
             }))
             .then(() => trial.id)
           )
-          .then((trial_id) => new Trial({ id: trial_id }).fetch({ withRelated: ['documents', 'documents.source'] }))
+          .then((trialId) => new Trial({ id: trialId }).fetch({ withRelated: ['documents', 'documents.source'] }))
           .then((trial) => should(trial.toJSON().sources).deepEqual({}))
-      });
+      ));
     });
 
     describe('discrepancies', () => {
       it('returns the discrepancies', () => {
-        let trial_id;
+        let trialId;
 
         return factory.create('trial')
-          .then((trial) => trial_id = trial.attributes.id)
+          .then((trial) => (trialId = trial.attributes.id))
           .then(() => factory.createMany('record', [
-              {
-                trial_id,
-                public_title: 'foo',
-                brief_summary: 'foo',
-                target_sample_size: 0,
-                gender: 'female',
-                registration_date: new Date('2016-01-01'),
-                status: 'complete',
-                recruitment_status: 'not_recruiting',
-                has_published_results: true,
-              },
-              {
-                trial_id,
-                public_title: 'bar',
-                brief_summary: 'bar',
-                target_sample_size: 100,
-                gender: 'both',
-                registration_date: new Date('2015-01-01'),
-                status: 'ongoing',
-                recruitment_status: 'recruiting',
-                has_published_results: false,
-              },
-           ]))
-          .then(() => new Trial({ id: trial_id }).fetch({ withRelated: ['records', 'records.source'] }))
+            {
+              trial_id: trialId,
+              public_title: 'foo',
+              brief_summary: 'foo',
+              target_sample_size: 0,
+              gender: 'female',
+              registration_date: new Date('2016-01-01'),
+              status: 'complete',
+              recruitment_status: 'not_recruiting',
+              has_published_results: true,
+            },
+            {
+              trial_id: trialId,
+              public_title: 'bar',
+              brief_summary: 'bar',
+              target_sample_size: 100,
+              gender: 'both',
+              registration_date: new Date('2015-01-01'),
+              status: 'ongoing',
+              recruitment_status: 'recruiting',
+              has_published_results: false,
+            },
+          ]))
+          .then(() => new Trial({ id: trialId }).fetch({ withRelated: ['records', 'records.source'] }))
           .then((trial) => {
             should(trial.discrepancies).have.properties([
               'gender',
@@ -353,7 +345,7 @@ describe('Trial', () => {
       });
 
       it('returns undefined if there\'re no discrepancies in the records', () => {
-        let trial_id;
+        let trialId;
 
         return factory.create('record')
           .then((record) => {
@@ -365,76 +357,76 @@ describe('Trial', () => {
               'recruitment_status',
               'has_published_status',
             ]);
-            trial_id = baseFields.trial_id;
+            trialId = baseFields.trial_id;
 
             return factory.create('record', baseFields);
           })
-          .then(() => new Trial({ id: trial_id }).fetch({ withRelated: ['records', 'records.source'] }))
+          .then(() => new Trial({ id: trialId }).fetch({ withRelated: ['records', 'records.source'] }))
           .then((trial) => should(trial.discrepancies).be.undefined());
       });
 
       it('ignores undefined fields', () => {
-        let trial_id;
+        let trialId;
 
         return factory.create('trial')
-          .then((trial) => trial_id = trial.attributes.id)
-          .then(() => factory.createMany('record', [{ trial_id, gender: 'male' }, { trial_id, gender: null }]))
-          .then(() => new Trial({ id: trial_id }).fetch({ withRelated: ['records', 'records.source'] }))
+          .then((trial) => (trialId = trial.attributes.id))
+          .then(() => factory.createMany('record', [{ trial_id: trialId, gender: 'male' }, { trial_id: trialId, gender: null }]))
+          .then(() => new Trial({ id: trialId }).fetch({ withRelated: ['records', 'records.source'] }))
           .then((trial) => should(trial.discrepancies).be.undefined());
       });
 
       it('ignores records from EU CTR', () => {
-        let trial_id;
+        let trialId;
 
         return factory.create('trial')
-          .then((trial) => trial_id = trial.attributes.id)
+          .then((trial) => (trialId = trial.attributes.id))
           .then(() => factory.create('source', { id: 'euctr' }))
           .then((euctr) => factory.createMany('record', [
             {
-              trial_id,
+              trial_id: trialId,
               source_id: euctr.id,
               gender: 'female',
             },
             {
-              trial_id,
+              trial_id: trialId,
               gender: 'both',
             },
           ]))
-          .then(() => new Trial({ id: trial_id }).fetch({ withRelated: ['records', 'records.source'] }))
+          .then(() => new Trial({ id: trialId }).fetch({ withRelated: ['records', 'records.source'] }))
           .then((trial) => should(trial.discrepancies).be.undefined());
       });
 
       it('ignores records from ICTRP', () => {
-        let trial_id;
+        let trialId;
 
         return factory.create('trial')
-          .then((trial) => trial_id = trial.attributes.id)
+          .then((trial) => (trialId = trial.attributes.id))
           .then(() => factory.create('source', { id: 'ictrp' }))
           .then((ictrp) => factory.createMany('record', [
             {
-              trial_id,
+              trial_id: trialId,
               source_id: ictrp.id,
               gender: 'female',
             },
             {
-              trial_id,
+              trial_id: trialId,
               gender: 'both',
             },
           ]))
-          .then(() => new Trial({ id: trial_id }).fetch({ withRelated: ['records', 'records.source'] }))
+          .then(() => new Trial({ id: trialId }).fetch({ withRelated: ['records', 'records.source'] }))
           .then((trial) => should(trial.discrepancies).be.undefined());
       });
     });
   });
 
   describe('toJSONSummary', () => {
-    it('returns simplified trial representation', () => {
-      return factory.create('trial')
+    it('returns simplified trial representation', () => (
+      factory.create('trial')
         .then((trial) => trial.toJSONSummary().should.deepEqual({
           id: trial.attributes.id,
           public_title: trial.attributes.public_title,
           url: trial.url,
-        }));
-    });
+        }))
+    ));
   });
 });

--- a/test/config/pg_types.js
+++ b/test/config/pg_types.js
@@ -2,24 +2,23 @@
 
 const should = require('should');
 const pgTypes = require('pg').types;
-const customTypes = require('../../config/pg_types');
+require('../../config/pg_types');
 
 describe('parseDate', () => {
   const DATE_OID = 1082;
   const parseDate = pgTypes.getTypeParser(DATE_OID);
 
   it('does not offset time', () => {
-    let testDate = '2016-12-01';
-    let expectedDate = new Date(testDate).toISOString();
-    let resultedDate = parseDate(testDate);
+    const testDate = '2016-12-01';
+    const expectedDate = new Date(testDate).toISOString();
+    const resultedDate = parseDate(testDate);
     resultedDate.toISOString().should.equal(expectedDate);
   });
 
   it('returns null when value is null', () => {
-    let testDate = null;
+    const testDate = null;
     should(parseDate(testDate)).equal(null);
   });
-
 });
 
 describe('parseDateArray', () => {
@@ -27,27 +26,27 @@ describe('parseDateArray', () => {
   const parseDateArray = pgTypes.getTypeParser(DATE_ARRAY_OID);
 
   it('parses array correctly', () => {
-    let testDate = '2014-01-12';
-    let testPgArray = `{${testDate}}`;
-    let expectedDate = new Date(testDate).toISOString();
-    let resultedArray = parseDateArray(testPgArray);
+    const testDate = '2014-01-12';
+    const testPgArray = `{${testDate}}`;
+    const expectedDate = new Date(testDate).toISOString();
+    const resultedArray = parseDateArray(testPgArray);
     resultedArray.map((date) => date.toISOString()).should.deepEqual([
       expectedDate,
     ]);
   });
 
   it('returns null when value is null', () => {
-    let testPgArray = null;
+    const testPgArray = null;
     should(parseDateArray(testPgArray)).equal(null);
   });
 
   it('returns empty array when there are no values', () => {
-    let testPgArray = `{}`;
+    const testPgArray = '{}';
     parseDateArray(testPgArray).should.be.empty();
   });
 
   it('returns null for the null values', () => {
-    let testPgArray = `{null}`;
+    const testPgArray = '{null}';
     parseDateArray(testPgArray).should.deepEqual([
       null,
     ]);

--- a/test/e2e/search.js
+++ b/test/e2e/search.js
@@ -3,25 +3,25 @@
 const should = require('should');
 
 describe('(e2e) search', () => {
-  it('should be successful', () => {
-    return server.inject('/v1/search')
+  it('should be successful', () => (
+    server.inject('/v1/search')
       .then((response) => {
         should(response.statusCode).eql(200);
         return JSON.parse(response.result);
       })
       .then((apiResponse) => should(apiResponse.failedValidation).be.undefined())
-  });
-})
+  ));
+});
 
 describe('(e2e) search FDA documents', () => {
-  it('should be successful', () => {
-    return server.inject('/v1/search/fda_documents')
+  it('should be successful', () => (
+    server.inject('/v1/search/fda_documents')
       .then((response) => {
         should(response.statusCode).eql(200);
         return JSON.parse(response.result);
       })
       .then((apiResponse) => should(apiResponse.failedValidation).be.undefined())
-  });
+  ));
 
   it('returns only documents that contain the "q" query string', () => {
     let sampleDocumentId;
@@ -42,7 +42,7 @@ describe('(e2e) search FDA documents', () => {
 
         should(result.items.length).eql(1);
         should(result.items[0].id).eql(sampleDocumentId);
-      })
+      });
   });
 
   it('returns only pages that contain the "text" query param, with terms highlighted', () => {
@@ -56,26 +56,27 @@ describe('(e2e) search FDA documents', () => {
         for (const doc of result.items) {
           // Only consider files with multiple pages to be able to test that
           // the other pages weren't returned
-          if (doc.file === undefined || doc.file.pages.length < 2) {
-            continue;
+          if (doc.file !== undefined && doc.file.pages.length >= 2) {
+            samplePage = doc.file.pages[0];
+            break;
           }
-
-          samplePage = doc.file.pages[0];
-          break;
         }
 
         // Safety net for the case we can't find any page in the DB
         should(samplePage).not.be.undefined();
       })
-      .then(() => server.inject(`/v1/search/fda_documents?text=${encodeURIComponent('"' + samplePage.text + '"')}`))
+      .then(() => server.inject(`/v1/search/fda_documents?text=${encodeURIComponent(`"${samplePage.text}"`)}`))
       .then((response) => {
         const result = JSON.parse(response.result);
-        const pages = result.items.reduce((result, doc) => {
+        const pages = result.items.reduce((items, doc) => {
           if (doc.file === undefined) {
-            return result;
+            return items;
           }
 
-          return result.concat(doc.file.pages);
+          return [
+            ...items,
+            ...doc.file.pages,
+          ];
         }, []);
         const highlightedTerms = samplePage.text
           .split(' ')
@@ -83,16 +84,16 @@ describe('(e2e) search FDA documents', () => {
           .join(' ');
 
         pages.forEach((page) => should(page.text).eql(highlightedTerms));
-      })
+      });
   });
 
-  it('returns all documents when called without parameters', () => {
+  it('returns all documents when called without parameters', () => (
     // This assumes that there're FDA Documents indexed
-    return server.inject('/v1/search/fda_documents')
+    server.inject('/v1/search/fda_documents')
       .then((response) => {
         const result = JSON.parse(response.result);
         should(result.total_count).above(0);
         should(result.items.length).above(0);
-      });
-  });
-})
+      })
+  ));
+});

--- a/test/integration/server.js
+++ b/test/integration/server.js
@@ -1,10 +1,12 @@
+'use strict';
+
 describe('server', () => {
   it('has CORS enabled', () => (
     server.inject({
       url: '/v1/swagger.yaml',
       headers: {
         Origin: 'http://foo.com',
-      }
+      },
     }).then((response) => {
       response.headers.should.containEql({ 'access-control-allow-origin': '*' });
     })

--- a/tools/indexers/autocomplete.js
+++ b/tools/indexers/autocomplete.js
@@ -85,7 +85,7 @@ function indexer(indexName) {
     .then(() => indexAutocompleteModel(Intervention, indexName, 'intervention'))
     .then(() => indexAutocompleteModel(Location, indexName, 'location'))
     .then(() => indexAutocompleteModel(Person, indexName, 'person'))
-    .then(() => indexAutocompleteModel(Organisation, indexName, 'organisation'))
+    .then(() => indexAutocompleteModel(Organisation, indexName, 'organisation'));
 }
 
 
@@ -93,4 +93,4 @@ module.exports = {
   alias: 'autocomplete',
   index: autocompleteIndex,
   indexer,
-}
+};

--- a/tools/indexers/fda_documents.js
+++ b/tools/indexers/fda_documents.js
@@ -2,7 +2,6 @@
 
 const esHelpers = require('./helpers');
 const Document = require('../../api/models/document');
-const client = require('../../config').elasticsearch;
 
 
 const fdaDocumentMapping = {
@@ -117,7 +116,7 @@ const fdaDocumentMapping = {
       },
     },
   },
-}
+};
 
 const pageMapping = {
   _parent: {
@@ -145,7 +144,7 @@ const index = {
       page: pageMapping,
     },
   },
-}
+};
 
 function indexer(name) {
   return indexerFDADocuments(name)
@@ -166,7 +165,7 @@ function indexerFDADocuments(name) {
       withRelated: Document.relatedModels,
     },
     (entities) => entities.models.map((entity) => entity.toJSONSummary())
-  )
+  );
 }
 
 function indexerPages(name) {
@@ -185,7 +184,7 @@ function indexerPages(name) {
     },
     _convertDocumentsFilesPages,
     1
-  )
+  );
 }
 
 function _convertDocumentsFilesPages(docs) {
@@ -199,7 +198,7 @@ function _convertDocumentsFilesPages(docs) {
         // Must add parent's ID because multiple documents can point to the
         // same file. This means we'll be indexing the same file multiple
         // times.
-        id: `${docJSON.id}_${docJSON.file.id}_${i+1}`,
+        id: `${docJSON.id}_${docJSON.file.id}_${i + 1}`,
       }
     )));
 
@@ -211,4 +210,4 @@ module.exports = {
   alias: 'fda_documents',
   index,
   indexer,
-}
+};

--- a/tools/indexers/helpers.js
+++ b/tools/indexers/helpers.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console, max-len */
+
 'use strict';
 
 const Promise = require('bluebird');
@@ -5,13 +7,11 @@ const client = require('../../config').elasticsearch;
 
 const defaultBatchSize = 1000;
 
-function indexModel(model, index, indexType, _queryParams, fetchOptions, entitiesConverter, batchSize) {
+function indexModel(model, index, indexType, _queryParams, fetchOptions, entitiesConverter, _batchSize) {
+  const batchSize = _batchSize || defaultBatchSize;
   let converter = entitiesConverter;
   if (converter === undefined) {
     converter = (entities) => entities;
-  }
-  if (batchSize === undefined) {
-    batchSize = defaultBatchSize;
   }
 
   return model.query(_queryParams).count().then((modelCount) => {
@@ -67,10 +67,14 @@ function _bulkIndexEntities(entities, index, indexType) {
 
     if (entity._parent !== undefined) {
       action.index._parent = entity._parent;
-      delete entity._parent;
+      delete entity._parent;  // eslint-disable-line no-param-reassign
     }
 
-    return result.concat([action, entity]);
+    return [
+      ...result,
+      action,
+      entity,
+    ];
   }, []);
 
   let result;
@@ -85,4 +89,4 @@ function _bulkIndexEntities(entities, index, indexType) {
 
 module.exports = {
   indexModel,
-}
+};

--- a/tools/indexers/index.js
+++ b/tools/indexers/index.js
@@ -1,7 +1,13 @@
+/* eslint-disable global-require */
+
 'use strict';
 
+const trials = require('./trials');
+const autocomplete = require('./autocomplete');
+const fdaDocuments = require('./fda_documents');
+
 module.exports = {
-  trials: require('./trials'),
-  autocomplete: require('./autocomplete'),
-  fdaDocuments: require('./fda_documents'),
-}
+  trials,
+  autocomplete,
+  fdaDocuments,
+};

--- a/tools/indexers/trials.js
+++ b/tools/indexers/trials.js
@@ -336,5 +336,5 @@ module.exports = {
   },
   indexer: (indexName) => (
     esHelpers.indexModel(Trial, indexName, 'trial', {}, { withRelated: Trial.relatedModels })
-  )
-}
+  ),
+};


### PR DESCRIPTION
ESLint complains when we use the `arguments` variable, pointing us towards
using rest parameters. However, in our NodeJS version, the rest parameters
aren't enabled by default, so we need to add `--harmony_rest_parameters` flag
when running node.

This won't be necessary when we upgrade our Node version.

Other than that, this commit only enables and fixes all ESLint errors.

opentrials/opentrials#529