### PR TITLE
[#467] Manage created_at and updated_at at db level

### DIFF
--- a/migrations/20170122130426_set_default_for_created_at_and_updated_at.js
+++ b/migrations/20170122130426_set_default_for_created_at_and_updated_at.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Promise = require('bluebird');
+
+const tablesWithTimestamps = ['conditions', 'fda_applications', 'fda_approvals',
+  'interventions', 'locations', 'organisations', 'persons', 'publications',
+  'records', 'risk_of_bias_criterias', 'risk_of_biases', 'sources', 'trials'];
+
+exports.up = (knex) => (
+  Promise.map(tablesWithTimestamps, (table) =>
+    knex.schema.raw(
+      `ALTER TABLE ${table}
+      ALTER COLUMN created_at SET DEFAULT now(),
+      ALTER COLUMN updated_at SET DEFAULT now();`
+    )
+  )
+);
+
+exports.down = (knex) => (
+  Promise.map(tablesWithTimestamps, (table) =>
+    knex.schema.raw(
+      `ALTER TABLE ${table}
+      ALTER COLUMN created_at DROP DEFAULT,
+      ALTER COLUMN updated_at DROP DEFAULT;`
+    )
+  )
+);

--- a/migrations/20170122185448_add_trigger_for_updated_at.js
+++ b/migrations/20170122185448_add_trigger_for_updated_at.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const Promise = require('bluebird');
+
+const tablesWithTimestamps = ['conditions', 'fda_applications', 'fda_approvals',
+  'interventions', 'locations', 'organisations', 'persons', 'publications',
+  'records', 'risk_of_bias_criterias', 'risk_of_biases', 'sources', 'trials'];
+
+exports.up = (knex) => (
+  knex.raw(
+    `CREATE FUNCTION set_updated_at()
+      RETURNS TRIGGER
+      LANGUAGE plpgsql
+    AS $$
+    BEGIN
+      NEW.updated_at := now();
+      RETURN NEW;
+    END;
+    $$;`
+  ).then(() =>
+     Promise.map(tablesWithTimestamps, (table) =>
+      knex.raw(
+        `CREATE TRIGGER ${table}_set_updated_at
+        BEFORE UPDATE ON ${table}
+        FOR EACH ROW EXECUTE PROCEDURE set_updated_at();`
+      )
+    )
+  )
+);
+
+exports.down = (knex) => (
+   Promise.map(tablesWithTimestamps, (table) =>
+    knex.raw(`DROP TRIGGER ${table}_set_updated_at ON ${table};`)
+  ).then(() =>
+    knex.raw('DROP FUNCTION set_updated_at();')
+  )
+);

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "precoveralls": "npm test",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "migrate": "knex migrate:latest",
+    "rollback": "knex migrate:rollback",
     "seed": "[ \"$NODE_ENV\" != \"production\" ] && knex seed:run || echo Can\\'t run seed in production",
     "start": "node --optimize_for_size --max_old_space_size=460 --gc_interval=100 server.js",
     "dev": "nodemon server.js",

--- a/seeds/trials.js
+++ b/seeds/trials.js
@@ -141,8 +141,6 @@ exports.seed = (knex) => {
   const publications = {
     publication1: {
       id: '7cd88d88-031d-11e6-b512-3e1d05defe00',
-      created_at: new Date('2016-01-01'),
-      updated_at: new Date('2016-04-01'),
       source_id: sources.nct.id,
       source_url: 'https://clinicaltrials.gov/ct2/show/NCT00000774',
       title: 'Test title1',
@@ -151,8 +149,6 @@ exports.seed = (knex) => {
     },
     publication2: {
       id: '7cd88d88-031d-11e6-b512-3e1d05defe01',
-      created_at: new Date('2016-01-01'),
-      updated_at: new Date('2016-04-01'),
       source_id: sources.nct.id,
       source_url: 'https://clinicaltrials.gov/ct2/show/NCT00000774',
       title: 'Test title2',
@@ -421,8 +417,6 @@ exports.seed = (knex) => {
       target_sample_size: 2000,
       gender: 'both',
       has_published_results: true,
-      created_at: new Date('2016-01-01'),
-      updated_at: new Date('2016-04-01'),
     },
     {
       id: '2e3406c4-031f-11e6-b512-3e1d05defe78',
@@ -442,8 +436,6 @@ exports.seed = (knex) => {
       study_design: 'Observational Model: Cohort, Time Perspective: Prospective',
       study_phase: ['Not applicable'],
       target_sample_size: 250,
-      created_at: new Date('2016-01-20'),
-      updated_at: new Date('2016-04-20'),
     },
     {
       id: '8e1e260c-4dad-4cc6-bab5-eb414cbde32d',
@@ -472,22 +464,16 @@ exports.seed = (knex) => {
     {
       id: '756b06ca-8414-11e6-a6fa-e4b3181a2c8c',
       name: 'blinding',
-      created_at: new Date('2016-01-02'),
-      updated_at: new Date('2016-02-01'),
     },
     {
       id: '7036b016-841c-11e6-a6fa-e4b3181a2c8c',
       name: 'detection bias',
-      created_at: new Date('2016-01-02'),
-      updated_at: new Date('2016-02-01'),
     },
   ];
 
   const riskOfBiases = [
     {
       id: 'fbc67980-83af-11e6-831c-e4b3181a2c8c',
-      created_at: new Date('2016-01-02'),
-      updated_at: new Date('2015-02-01'),
       source_id: sources.cochrane.id,
       trial_id: trials[0].id,
       source_url: 'http://onlinelibrary.wiley.com/doi/10.1002/14651858.CD006081/full',
@@ -495,8 +481,6 @@ exports.seed = (knex) => {
     },
     {
       id: '44470c86-83ee-11e6-a6fa-e4b3181a2c8c',
-      created_at: new Date('2016-02-03'),
-      updated_at: new Date('2016-03-02'),
       source_id: sources.cochrane.id,
       trial_id: trials[1].id,
       source_url: 'http://onlinelibrary.wiley.com/doi/10.1002/14651858.CD009766/full',

--- a/test/factory.js
+++ b/test/factory.js
@@ -246,11 +246,9 @@ factory.define('sourceRelatedToSeveralRecords', Source, {
     const records = [
       {
         source_id: source.id,
-        updated_at: new Date('2015-01-01'),
       },
       {
         source_id: source.id,
-        updated_at: new Date('2016-01-01'),
       },
     ];
 


### PR DESCRIPTION
opentrials/opentrials#467

Currently `updated_at` and `created_at` fields are of type `TIMESTAMP WITH TIME ZONE`. Until now, we [made sure in the code that the timezone will be UTC](https://github.com/opentrials/processors/blob/master/processors/base/writers/condition.py#L33). However, after this change, if we keep the timezone, we have to [tell PostgreSQL to use UTC by editing `postgresql.conf`](https://www.postgresql.org/docs/9.1/static/runtime-config-client.html#GUC-TIMEZONE). 