### PR TITLE
Fix automatic PR deployment to Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -18,7 +18,7 @@
       }
     },
     {
-      "plan": "bonsai:sandbox",
+      "plan": "bonsai:sandbox-10",
       "options": {
         "version": "2.3"
       }


### PR DESCRIPTION
The Bonsai add-on changed its plan name from `sandbox` to `sandbox-10`.