### PR TITLE
[#187] Don't allow "npm run seed" in production

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -11,6 +11,10 @@ const db = {
     client: 'pg',
     connection: process.env.DATABASE_URL,
   },
+  staging: {
+    client: 'pg',
+    connection: process.env.DATABASE_URL,
+  },
   test: {
     client: 'pg',
     connection: process.env.TEST_DATABASE_URL,

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "precoveralls": "npm test",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "migrate": "knex migrate:latest",
-    "seed": "knex seed:run",
+    "seed": "[ \"$NODE_ENV\" != \"production\" ] && npm run seed || echo Can\\'t run seed in production",
     "start": "node --optimize_for_size --max_old_space_size=460 --gc_interval=100 server.js",
     "dev": "nodemon server.js",
     "reindex": "node --optimize_for_size --max_old_space_size=460 --gc_interval=100 ./tools/reindex.js"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "precoveralls": "npm test",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "migrate": "knex migrate:latest",
-    "seed": "[ \"$NODE_ENV\" != \"production\" ] && npm run seed || echo Can\\'t run seed in production",
+    "seed": "[ \"$NODE_ENV\" != \"production\" ] && knex seed:run || echo Can\\'t run seed in production",
     "start": "node --optimize_for_size --max_old_space_size=460 --gc_interval=100 server.js",
     "dev": "nodemon server.js",
     "reindex": "node --optimize_for_size --max_old_space_size=460 --gc_interval=100 ./tools/reindex.js"


### PR DESCRIPTION
We only allow `npm run seed` if `NODE_ENV == "production"`. This avoids us
cleaning our production database by mistake.

Fixes opentrials/opentrials#187