### PR TITLE
Add `document_categories` endpoint

### DIFF
--- a/api/controllers/document_categories.js
+++ b/api/controllers/document_categories.js
@@ -2,24 +2,6 @@
 
 const DocumentCategory = require('../models/document_category');
 
-function getDocumentCategory(req, res) {
-  const id = req.swagger.params.id.value;
-
-  return new DocumentCategory({ id }).fetch()
-    .then((doc) => {
-      if (doc) {
-        res.json(doc);
-      } else {
-        res.status(404);
-        res.finish();
-      }
-    })
-    .catch((err) => {
-      res.finish();
-      throw err;
-    });
-}
-
 function listDocumentCategories(req, res) {
   return DocumentCategory.fetchAll()
     .then((categories) => {
@@ -36,6 +18,5 @@ function listDocumentCategories(req, res) {
 }
 
 module.exports = {
-  getDocumentCategory,
   listDocumentCategories,
 };

--- a/api/controllers/document_categories.js
+++ b/api/controllers/document_categories.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const DocumentCategory = require('../models/document_category');
+
+function getDocumentCategory(req, res) {
+  const id = req.swagger.params.id.value;
+
+  return new DocumentCategory({ id }).fetch()
+    .then((doc) => {
+      if (doc) {
+        res.json(doc);
+      } else {
+        res.status(404);
+        res.finish();
+      }
+    })
+    .catch((err) => {
+      res.finish();
+      throw err;
+    });
+}
+
+function listDocumentCategories(req, res) {
+  return DocumentCategory.fetchAll()
+    .then((categories) => {
+      const response = {
+        total_count: categories.length,
+        items: categories.models.map((m) => m.toJSON()),
+      };
+      res.json(response);
+    })
+    .catch((err) => {
+      res.finish();
+      throw err;
+    });
+}
+
+module.exports = {
+  getDocumentCategory,
+  listDocumentCategories,
+};

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -471,31 +471,6 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
 
-  /document_categories/{id}:
-    x-swagger-router-controller: document_categories
-    get:
-      tags:
-        - document_categories
-      description: Returns a single document category
-      operationId: getDocumentCategory
-      parameters:
-        - name: id
-          in: path
-          description: ID of the document
-          required: true
-          type: string
-      responses:
-        "200":
-          description: Success
-          schema:
-            $ref: "#/definitions/DocumentCategory"
-        "404":
-          description: Category not found
-        default:
-          description: Error
-          schema:
-            $ref: "#/definitions/ErrorResponse"
-
   /document_categories:
     x-swagger-router-controller: document_categories
     get:

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -471,6 +471,48 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
 
+  /document_categories/{id}:
+    x-swagger-router-controller: document_categories
+    get:
+      tags:
+        - document_categories
+      description: Returns a single document category
+      operationId: getDocumentCategory
+      parameters:
+        - name: id
+          in: path
+          description: ID of the document
+          required: true
+          type: string
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/DocumentCategory"
+        "404":
+          description: Category not found
+        default:
+          description: Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+
+  /document_categories:
+    x-swagger-router-controller: document_categories
+    get:
+      tags:
+        - document_categories
+      description: Returns document categories
+      operationId: listDocumentCategories
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/DocumentCategoryList"
+        default:
+          description: Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+
 definitions:
   Trial:
     type: object
@@ -1065,6 +1107,19 @@ definitions:
       name:
         type: string
         description: Name of document sub-category
+
+  DocumentCategoryList:
+    type: object
+    required:
+      - total_count
+      - items
+    properties:
+      total_count:
+        type: integer
+      items:
+        type: array
+        items:
+          $ref: '#/definitions/DocumentCategory'
 
   DocumentList:
     type: object

--- a/test/api/controllers/document_categories.js
+++ b/test/api/controllers/document_categories.js
@@ -1,0 +1,58 @@
+/* eslint-disable max-len */
+
+'use strict';
+
+const DocumentCategory = require('../../../api/models/document_category');
+
+describe('Document category', () => {
+  before(clearDB);
+
+  afterEach(clearDB);
+
+  describe('GET /v1/document_categories/{id}', () => {
+    it('returns 404 if there\'s no document with the received ID', () => (
+      server.inject('/v1/document_categories/0')
+        .then((response) => {
+          response.statusCode.should.equal(404);
+        })
+    ));
+
+    it('returns a document category', () => {
+      let cat;
+
+      return factory.create('document_category')
+        .then((_cat) => new DocumentCategory({ id: _cat.attributes.id }).fetch())
+        .then((_cat) => (cat = _cat))
+        .then(() => server.inject(`/v1/document_categories/${cat.attributes.id}`))
+        .then((response) => {
+          response.statusCode.should.equal(200);
+
+          const expectedResult = cat.toJSON();
+          const result = JSON.parse(response.result);
+
+          result.should.deepEqual(expectedResult);
+        });
+    });
+  });
+
+  describe('GET /v1/document_categories', () => {
+    it('returns the document categories', () => {
+      let cat;
+
+      return factory.create('document_category')
+        .then((_cat) => new DocumentCategory({ id: _cat.attributes.id }).fetch())
+        .then((_cat) => (cat = _cat))
+        .then(() => server.inject('/v1/document_categories'))
+        .then((response) => {
+          response.statusCode.should.equal(200);
+
+          const expectedResult = {
+            total_count: 1,
+            items: [cat.toJSON()],
+          };
+          const result = JSON.parse(response.result);
+          result.should.deepEqual(toJSON(expectedResult));
+        });
+    });
+  });
+});

--- a/test/api/controllers/document_categories.js
+++ b/test/api/controllers/document_categories.js
@@ -9,32 +9,6 @@ describe('Document category', () => {
 
   afterEach(clearDB);
 
-  describe('GET /v1/document_categories/{id}', () => {
-    it('returns 404 if there\'s no document with the received ID', () => (
-      server.inject('/v1/document_categories/0')
-        .then((response) => {
-          response.statusCode.should.equal(404);
-        })
-    ));
-
-    it('returns a document category', () => {
-      let cat;
-
-      return factory.create('document_category')
-        .then((_cat) => new DocumentCategory({ id: _cat.attributes.id }).fetch())
-        .then((_cat) => (cat = _cat))
-        .then(() => server.inject(`/v1/document_categories/${cat.attributes.id}`))
-        .then((response) => {
-          response.statusCode.should.equal(200);
-
-          const expectedResult = cat.toJSON();
-          const result = JSON.parse(response.result);
-
-          result.should.deepEqual(expectedResult);
-        });
-    });
-  });
-
   describe('GET /v1/document_categories', () => {
     it('returns the document categories', () => {
       let cat;


### PR DESCRIPTION
As described in opentrials/opentrials#685, we now have an endpoint for exposing
the document categories from the API instead of storing them in Explorer.