### PR TITLE
[#646] Stop reindex at ElasticSearch error and keep old index

### DIFF
--- a/tools/reindex.js
+++ b/tools/reindex.js
@@ -19,13 +19,12 @@ function runIndexer(indexDefinition, alias, indexer) {
   return Promise.resolve()
     .then(() => client.indices.create(mapping))
     .then(() => indexer(index))
+    .catch((err) => removeIndexes([index]).then(() => { throw err; }))
+    .then(() => updateAlias(index, alias))
     .catch((err) => {
-      const errors = [].concat(err);
-      errors.map((error) => console.error(error));
-      removeIndexes([index])
-        .then(() => process.exit(-1));
-    })
-    .then(() => updateAlias(index, alias));
+      console.error(err);
+      process.exit(-1);
+    });
 }
 
 function uniqueIndexName(alias) {

--- a/tools/reindex.js
+++ b/tools/reindex.js
@@ -19,6 +19,12 @@ function runIndexer(indexDefinition, alias, indexer) {
   return Promise.resolve()
     .then(() => client.indices.create(mapping))
     .then(() => indexer(index))
+    .catch((err) => {
+      const errors = [].concat(err);
+      errors.map((error) => console.error(error));
+      removeIndexes([index])
+        .then(() => process.exit(-1));
+    })
     .then(() => updateAlias(index, alias));
 }
 
@@ -62,7 +68,7 @@ function removeIndexes(indexes) {
   let result;
 
   if (indexes) {
-    console.log('Removing old indexes:', indexes.join(', '));
+    console.log('Removing indexes:', indexes.join(', '));
     result = client.indices.delete({ index: indexes, ignore: 404 });
   }
 


### PR DESCRIPTION
Fixes opentrials/opentrials#646

Desired changes:
- stop `reindex` if indexing errors are encountered
- delete the new (unfinished) index and fallback to the old one if errors are encountered
- show errors

To test add `dynamic: 'strict',` [in the `trials` index mapping](https://github.com/opentrials/api/blob/master/tools/indexers/trials.js#L17) (on the same level with `properties`).