### PR TITLE
[#725] Add migration to set study_phase = NULL where it's [null]

### DIFF
--- a/migrations/20170406122708_set_study_phase_arrays_with_null_element_to_null.js
+++ b/migrations/20170406122708_set_study_phase_arrays_with_null_element_to_null.js
@@ -1,0 +1,11 @@
+'use strict';
+
+exports.up = (knex) => (
+  knex.schema
+    .raw("UPDATE trials SET study_phase = NULL WHERE study_phase = '{null}'")
+    .raw("UPDATE records SET study_phase = NULL WHERE study_phase = '{null}'")
+);
+
+exports.down = () => {
+  throw Error('Destructive migration can\'t be rolled back.');
+};


### PR DESCRIPTION
The migration that converted `study_phase` to be a `text[]` converted the
current study phases to a single-element array, including null study phases.
Because of this, we ended up with invalid study phases like `[null]`.

Fixes opentrials/opentrials#725