### PR TITLE
[#708] Change PubMed source type to 'journal'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ services:
 before_install:
   - curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.5/elasticsearch-2.3.5.deb && sudo dpkg -i --force-confnew elasticsearch-2.3.5.deb && sudo service elasticsearch restart
 before_script:
+  - touch .env
   - psql -c 'create database opentrials_api_test;' -U postgres
   - npm run migrate
   # Run seed twice to make sure we're cleaning the DB correctly

--- a/migrations/20170407155833_change-pubmed-source-type-to-journal.js
+++ b/migrations/20170407155833_change-pubmed-source-type-to-journal.js
@@ -1,0 +1,18 @@
+'use strict';
+
+exports.up = (knex) => (
+  knex.schema
+    .raw('ALTER TABLE sources DROP CONSTRAINT sources_type_check;')
+    .raw(`ALTER TABLE sources ADD CONSTRAINT sources_type_check
+          CHECK (type = ANY (ARRAY['register'::text, 'other'::text, 'journal'::text]))`)
+    .raw('UPDATE sources SET type = \'journal\' WHERE id = \'pubmed\'')
+);
+
+exports.down = (knex) => (
+  knex.schema
+    .raw('UPDATE sources SET type = \'other\' WHERE id = \'pubmed\'')
+    .raw('ALTER TABLE sources DROP CONSTRAINT sources_type_check;')
+    .raw(`ALTER TABLE sources ADD CONSTRAINT sources_type_check
+          CHECK (type = ANY (ARRAY['register'::text, 'other'::text]))
+    `)
+);

--- a/seeds/trials.js
+++ b/seeds/trials.js
@@ -134,7 +134,7 @@ exports.seed = (knex) => {
     pubmed: {
       id: 'pubmed',
       name: 'PubMed',
-      type: 'other',
+      type: 'journal',
     },
   };
 


### PR DESCRIPTION
Cannot alter type enum, since knex doesn't work as one would expect, by creating a new type represented by an enum. Which is super convenient, given how painful is to alter types (can hardly add new enum values, cannot easily remove them).

Long story short: new migration to add a new `sources.type` for PubMed, named `journal` by replacing the check constraint in place. Rollback possible.